### PR TITLE
Bake sorted listeners in HandlerList instead of re-sorting on event dispatch

### DIFF
--- a/common/src/main/java/org/bukkit/event/HandlerList.java
+++ b/common/src/main/java/org/bukkit/event/HandlerList.java
@@ -1,12 +1,17 @@
 package org.bukkit.event;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 public class HandlerList {
 	private static final List<HandlerList> allLists = new ArrayList<>();
 
+	private static final RegisteredListener[] EMPTY = new RegisteredListener[0];
+
 	private final List<RegisteredListener> listeners = new ArrayList<>();
+
+	private volatile RegisteredListener[] baked = EMPTY;
 
 	public HandlerList() {
 		synchronized (allLists) {
@@ -16,10 +21,12 @@ public class HandlerList {
 
 	public synchronized void register(RegisteredListener handler) {
 		listeners.add(handler);
+		baked = bake();
 	}
 
 	public synchronized void unregister(Listener listener) {
 		listeners.removeIf((registeredListener) -> registeredListener.getListener() == listener);
+		baked = bake();
 	}
 
 	public static void unregisterAll(Listener listener) {
@@ -32,7 +39,22 @@ public class HandlerList {
 		}
 	}
 
+	public RegisteredListener[] getBakedListeners() {
+		return baked;
+	}
+
 	public synchronized List<RegisteredListener> getRegisteredListeners() {
 		return List.copyOf(listeners);
+	}
+
+	private RegisteredListener[] bake() {
+		RegisteredListener[] baked = listeners.toArray(EMPTY);
+		Arrays.sort(baked, (a, b) -> {
+			int priorityA = a.getPriority().ordinal();
+			int priorityB = b.getPriority().ordinal();
+
+			return Integer.compare(priorityB, priorityA);
+		});
+		return baked;
 	}
 }

--- a/common/src/main/java/org/bukkit/event/HandlerList.java
+++ b/common/src/main/java/org/bukkit/event/HandlerList.java
@@ -48,7 +48,7 @@ public class HandlerList {
 	}
 
 	private RegisteredListener[] bake() {
-		RegisteredListener[] baked = listeners.toArray(EMPTY);
+		RegisteredListener[] baked = listeners.toArray(RegisteredListener[]::new);
 		Arrays.sort(baked, (a, b) -> {
 			int priorityA = a.getPriority().ordinal();
 			int priorityB = b.getPriority().ordinal();

--- a/common/src/main/java/org/bukkit/event/HandlerList.java
+++ b/common/src/main/java/org/bukkit/event/HandlerList.java
@@ -40,7 +40,7 @@ public class HandlerList {
 	}
 
 	public List<RegisteredListener> getBakedListeners() {
-		return baked;
+		return List.of(baked);
 	}
 
 	public synchronized List<RegisteredListener> getRegisteredListeners() {

--- a/common/src/main/java/org/bukkit/event/HandlerList.java
+++ b/common/src/main/java/org/bukkit/event/HandlerList.java
@@ -39,7 +39,7 @@ public class HandlerList {
 		}
 	}
 
-	public RegisteredListener[] getBakedListeners() {
+	public List<RegisteredListener> getBakedListeners() {
 		return baked;
 	}
 

--- a/common/src/main/java/org/bukkit/plugin/SimplePluginManager.java
+++ b/common/src/main/java/org/bukkit/plugin/SimplePluginManager.java
@@ -8,7 +8,6 @@ import java.io.File;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.MalformedURLException;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -63,16 +62,8 @@ public class SimplePluginManager implements PluginManager {
 
 	public void callEvent(Event event) {
 		HandlerList handlerList = event.getHandlers();
-		List<RegisteredListener> handlers = new ArrayList<>(handlerList.getRegisteredListeners());
 
-		handlers.sort((a, b) -> {
-			int priorityA = a.getPriority().ordinal();
-			int priorityB = b.getPriority().ordinal();
-
-			return Integer.compare(priorityB, priorityA);
-		});
-
-		for (RegisteredListener handler : handlers) {
+		for (RegisteredListener handler : handlerList.getBakedListeners()) {
 			if (event instanceof Cancellable && ((Cancellable) event).isCancelled() && handler.isIgnoreCancelled())
 				continue;
 			handler.getExecutor().execute(handler.getListener(), event);


### PR DESCRIPTION
`SimplePluginManager#callEvent` sorts the listeners on every event dispatch. The listener set only changes when something registers or unregisters. This change moves the sort into `HandlerList`, done once when listeners change, and `callEvent` just reads the cached result. 

