### PR TITLE
feat: armor change event

### DIFF
--- a/minestom/src/main/java/ch/njol/skript/events/EvtArmorChange.java
+++ b/minestom/src/main/java/ch/njol/skript/events/EvtArmorChange.java
@@ -3,6 +3,7 @@ package ch.njol.skript.events;
 import ch.njol.skript.Skript;
 import ch.njol.skript.events.wrapper.EntityEquipWrapper;
 import ch.njol.skript.lang.Literal;
+import ch.njol.skript.registrations.Classes;
 import ch.njol.skript.lang.SkriptEvent;
 import ch.njol.skript.lang.SkriptParser;
 import net.minestom.server.entity.EquipmentSlot;

--- a/minestom/src/main/java/ch/njol/skript/events/EvtArmorChange.java
+++ b/minestom/src/main/java/ch/njol/skript/events/EvtArmorChange.java
@@ -55,7 +55,7 @@ public class EvtArmorChange extends SkriptEvent {
 
 	@Override
 	public String toString(@Nullable Event event, boolean debug) {
-		return (slot == null ? "armor" : slot.name().toLowerCase(Locale.ENGLISH)) + " change";
+		return (slot == null ? "armor" : Classes.toString(slot)) + " change";
 	}
 
 }

--- a/minestom/src/main/java/ch/njol/skript/events/EvtArmorChange.java
+++ b/minestom/src/main/java/ch/njol/skript/events/EvtArmorChange.java
@@ -1,0 +1,61 @@
+package ch.njol.skript.events;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.events.wrapper.EntityEquipWrapper;
+import ch.njol.skript.lang.Literal;
+import ch.njol.skript.lang.SkriptEvent;
+import ch.njol.skript.lang.SkriptParser;
+import net.minestom.server.entity.EquipmentSlot;
+import org.bukkit.event.Event;
+import org.eclipse.jdt.annotation.Nullable;
+
+import java.util.Locale;
+
+public class EvtArmorChange extends SkriptEvent {
+
+	static {
+		Skript.registerEvent("Armor Change", EvtArmorChange.class, EntityEquipWrapper.class,
+				"[entity] armo[u]r chang(e|ing)",
+				"[entity] (1:helmet|2:chestplate|3:leggings|4:boots) chang(e|ing)")
+			.description("""
+				Called when an entity equips or unequips a piece of armor.
+				This is fired before the armor is applied, so 'past event-item' is the piece being replaced \
+				and 'event-item' is the piece being put on. Setting 'event-item' changes what ends up equipped.
+				This event cannot be cancelled.""")
+			.examples("""
+				on armor change:
+					broadcast "%event-entity% swapped %past event-item% for %event-item% in their %event-equipment slot%"
+
+				on helmet change:
+					if event-item is a diamond helmet:
+						send "nice helmet" to event-entity""");
+	}
+
+	private @Nullable EquipmentSlot slot;
+
+	@Override
+	public boolean init(Literal<?>[] args, int matchedPattern, SkriptParser.ParseResult parseResult) {
+		slot = switch (parseResult.mark) {
+			case 1 -> EquipmentSlot.HELMET;
+			case 2 -> EquipmentSlot.CHESTPLATE;
+			case 3 -> EquipmentSlot.LEGGINGS;
+			case 4 -> EquipmentSlot.BOOTS;
+			default -> null;
+		};
+		return true;
+	}
+
+	@Override
+	public boolean check(Event event) {
+		if (!(event instanceof EntityEquipWrapper wrapper)) return false;
+		EquipmentSlot changedSlot = wrapper.getEvent().getSlot();
+		if (slot != null) return changedSlot == slot;
+		return changedSlot.isArmor();
+	}
+
+	@Override
+	public String toString(@Nullable Event event, boolean debug) {
+		return (slot == null ? "armor" : slot.name().toLowerCase(Locale.ENGLISH)) + " change";
+	}
+
+}

--- a/minestom/src/main/java/ch/njol/skript/events/SimpleEvents.java
+++ b/minestom/src/main/java/ch/njol/skript/events/SimpleEvents.java
@@ -95,11 +95,6 @@ public class SimpleEvents {
 		Skript.registerEvent("Bundle Item Select", SimpleEvent.class, InventoryBundleItemSelectWrapper.class, "bundle item select")
 			.description("Called when a player scrolls on an item to select a bundle item. Also called when the player stops hovering over the item.")
 			.examples("on bundle item select:");
-		Skript.registerEvent("Arm Swing", SimpleEvent.class, PlayerHandAnimationWrapper.class, "[player] arm swing")
-			.description("Called when a player swings their arm.")
-			.examples("""
-				on arm swing:
-					broadcast "%event-player% swung their %event-player hand%\"""");
 		Skript.registerEvent("Effect Command", SimpleEvent.class, EffectCommandEvent.class, "effect command")
 			.description("Called when a player runs an effect command.")
 			.examples("on effect command:");

--- a/minestom/src/main/java/ch/njol/skript/events/SimpleEvents.java
+++ b/minestom/src/main/java/ch/njol/skript/events/SimpleEvents.java
@@ -95,6 +95,11 @@ public class SimpleEvents {
 		Skript.registerEvent("Bundle Item Select", SimpleEvent.class, InventoryBundleItemSelectWrapper.class, "bundle item select")
 			.description("Called when a player scrolls on an item to select a bundle item. Also called when the player stops hovering over the item.")
 			.examples("on bundle item select:");
+		Skript.registerEvent("Arm Swing", SimpleEvent.class, PlayerHandAnimationWrapper.class, "[player] arm swing")
+			.description("Called when a player swings their arm.")
+			.examples("""
+				on arm swing:
+					broadcast "%event-player% swung their %event-player hand%\"""");
 		Skript.registerEvent("Effect Command", SimpleEvent.class, EffectCommandEvent.class, "effect command")
 			.description("Called when a player runs an effect command.")
 			.examples("on effect command:");

--- a/minestom/src/main/java/ch/njol/skript/events/wrapper/EntityEquipWrapper.java
+++ b/minestom/src/main/java/ch/njol/skript/events/wrapper/EntityEquipWrapper.java
@@ -5,6 +5,7 @@ import ch.njol.skript.events.wrapper.marker.EntityInstanceEventMarker;
 import ch.njol.skript.registrations.EventValues;
 import ch.njol.skript.util.Item;
 import net.minestom.server.entity.EquipmentSlot;
+import net.minestom.server.entity.LivingEntity;
 import net.minestom.server.event.item.EntityEquipEvent;
 import org.skriptlang.skript.bukkit.lang.eventvalue.EventValue;
 
@@ -14,6 +15,13 @@ public class EntityEquipWrapper extends EventWrapper<EntityEquipEvent> implement
 		EventValues.registerEventValue(EventValue.builder(EntityEquipWrapper.class, Item.class)
 			.getter(from -> new Item(from.event.getEquippedItem()))
 			.registerChanger(Changer.ChangeMode.SET, (event, value) -> event.event.setEquippedItem(value.getItem()))
+			.build());
+		EventValues.registerEventValue(EventValue.builder(EntityEquipWrapper.class, Item.class)
+			.getter(from -> {
+				if (!(from.event.getEntity() instanceof LivingEntity entity)) return null;
+				return new Item(entity.getEquipment(from.event.getSlot()));
+			})
+			.time(EventValue.Time.PAST)
 			.build());
 		EventValues.registerEventValue(EventValue.simple(EntityEquipWrapper.class, EquipmentSlot.class, from -> from.event.getSlot()));
 	}

--- a/minestom/src/main/java/com/github/hapily04/skriptminestom/SkriptMinestom.java
+++ b/minestom/src/main/java/com/github/hapily04/skriptminestom/SkriptMinestom.java
@@ -53,7 +53,9 @@ import java.io.File;
 import java.lang.reflect.Constructor;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
+import java.util.HashSet;
 import java.util.Properties;
+import java.util.Set;
 
 import static com.github.hapily04.skriptminestom.util.MessageUtils.BASIC_MINI_MESSAGE;
 import static com.github.hapily04.skriptminestom.util.MessageUtils.SKRIPT_MINI_MESSAGE;
@@ -152,9 +154,11 @@ public class SkriptMinestom {
 		GlobalEventHandler geh = MinecraftServer.getGlobalEventHandler();
 		EventNode<net.minestom.server.event.Event> skriptEventNode = EventNode.all("skript-user-events").setPriority(50);
 		geh.addChild(skriptEventNode);
+		Set<Class<? extends Event>> listeningFor = new HashSet<>();
 		for (SkriptEventInfo<?> eventInfo : Skript.getEvents()) {
 			for (Class<? extends Event> bukkitEventClazz : eventInfo.events) {
 				if (!EventWrapper.class.isAssignableFrom(bukkitEventClazz)) continue;
+				if (!listeningFor.add(bukkitEventClazz)) continue;
 				Constructor<? extends Event> constructor = null;
 				Class<? extends Event> eventType = null;
 				for (Constructor<?> c :  bukkitEventClazz.getDeclaredConstructors()) {


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->
Adds 
```
"[entity] armo[u]r chang(e|ing)",
"[entity] (1:helmet|2:chestplate|3:leggings|4:boots) chang(e|ing)")
```

Tested with the code below
```
on armor change:
    add 1 to {-armor::count}
    broadcast "[armor #%{-armor::count}%] %event-equipment slot%: %past event-item% -> %event-item%"

on helmet change:
    broadcast "    ^ helmet change also fired"

on entity equip:
    add 1 to {-equip::count}
    broadcast "[equip #%{-equip::count}%] %event-equipment slot%"

command /armortest:
    trigger:
        clear {-armor::count}
        clear {-equip::count}
        broadcast "--- equipping diamond helmet ---"
        set helmet of player to diamond helmet
        wait 1 second
        broadcast "--- equipping iron chestplate ---"
        set chestplate of player to iron chestplate
        wait 1 second
        broadcast "--- replacing helmet with gold helmet ---"
        set helmet of player to golden helmet
        wait 1 second
        broadcast "--- equipping sword (main hand, should NOT fire armor change) ---"
        set tool of player to diamond sword
```
Results:
<img width="1334" height="506" alt="{50C0D7F9-B42D-4C5D-AE2B-C3BB67E95C6A}" src="https://github.com/user-attachments/assets/1a1ca063-461c-48e8-b42b-397afdf1578f" />

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
