### PR TITLE
Remove permission checks from LuckPermsPlayer in favor of Permissible

### DIFF
--- a/minestom/src/main/java/ch/njol/skript/conditions/CondHasPermission.java
+++ b/minestom/src/main/java/ch/njol/skript/conditions/CondHasPermission.java
@@ -11,10 +11,10 @@ import ch.njol.skript.lang.Condition;
 import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.util.Kleenean;
-import com.github.hapily04.skriptminestom.luckperms.LuckPermsPlayer;
 import net.minestom.server.command.CommandSender;
 import net.minestom.server.command.ConsoleSender;
 import org.bukkit.event.Event;
+import org.bukkit.permissions.Permissible;
 import org.jetbrains.annotations.Nullable;
 
 /**
@@ -54,7 +54,7 @@ public class CondHasPermission extends Condition {
 			s -> permissions.check(e,
 				perm -> {
 					if (s instanceof ConsoleSender) return true;
-					return ((LuckPermsPlayer) s).hasPermission(perm);
+					return ((Permissible) s).hasPermission(perm);
 				}), isNegated());
 	}
 

--- a/minestom/src/main/java/com/github/hapily04/skriptminestom/SkriptMinestom.java
+++ b/minestom/src/main/java/com/github/hapily04/skriptminestom/SkriptMinestom.java
@@ -46,6 +46,7 @@ import net.minestom.server.event.GlobalEventHandler;
 import net.minestom.server.event.player.PlayerChatEvent;
 import org.bukkit.Bukkit;
 import org.bukkit.event.Event;
+import org.bukkit.permissions.Permissible;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.PluginManager;
 
@@ -176,8 +177,8 @@ public class SkriptMinestom {
 	private static void initEffectCommands() {
 		MinecraftServer.getGlobalEventHandler().addListener(PlayerChatEvent.class, event -> {
 			if (!SkriptConfig.enableEffectCommands.value()) return;
-			LuckPermsPlayer player = (LuckPermsPlayer) event.getPlayer();
-			if (!player.hasPermission("skript.effectcommands")) return;
+			Player player = event.getPlayer();
+			if (!((Permissible) player).hasPermission("skript.effectcommands")) return;
 			String message = event.getRawMessage();
 			if (!message.startsWith(SkriptConfig.effectCommandToken.value())) return;
 			event.setCancelled(true);

--- a/minestom/src/main/java/com/github/hapily04/skriptminestom/luckperms/LuckPermsPlayer.java
+++ b/minestom/src/main/java/com/github/hapily04/skriptminestom/luckperms/LuckPermsPlayer.java
@@ -14,6 +14,8 @@ import net.minestom.server.command.ConsoleSender;
 import net.minestom.server.entity.Player;
 import net.minestom.server.network.player.GameProfile;
 import net.minestom.server.network.player.PlayerConnection;
+import org.bukkit.permissions.Permissible;
+import org.bukkit.permissions.Permission;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.jetbrains.annotations.NotNull;
 
@@ -23,10 +25,11 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 
-public class LuckPermsPlayer extends Player {
+public class LuckPermsPlayer extends Player implements Permissible {
 
     private final @NotNull LuckPerms luckPerms;
     private final @NonNull PlayerAdapter<Player> playerAdapter;
+    private boolean op;
 
     public LuckPermsPlayer(@NotNull LuckPerms luckPerms, @NotNull PlayerConnection connection, @NotNull GameProfile profile) {
         super(connection, profile);
@@ -114,8 +117,29 @@ public class LuckPermsPlayer extends Player {
      * @param permissionName the name of the permission to check
      * @return true if the player has the permission
      */
+    @Override
     public boolean hasPermission(@NotNull String permissionName) {
 		return this.getPermission(permissionName).asBoolean();
+    }
+
+    @Override
+    public boolean isPermissionSet(@NotNull String name) {
+        return getPermission(name) != Tristate.UNDEFINED;
+    }
+
+    @Override
+    public boolean isPermissionSet(@NotNull Permission perm) {
+        return false;
+    }
+
+    @Override
+    public boolean isOp() {
+        return op;
+    }
+
+    @Override
+    public void setOp(boolean value) {
+        this.op = value;
     }
 
     /**
@@ -152,7 +176,7 @@ public class LuckPermsPlayer extends Player {
     }
 
     public static boolean hasPermission(CommandSender sender, String permissionNode) {
-        return sender instanceof ConsoleSender || (sender instanceof LuckPermsPlayer lp && lp.hasPermission(permissionNode));
+        return sender instanceof ConsoleSender || (sender instanceof Permissible p && p.hasPermission(permissionNode));
     }
 
 }


### PR DESCRIPTION
### Description
Permissible exists in common, but nothing implements or uses it. CondHasPermission and the /skript command permission checks cast to LuckPermsPlayer instead.

- LuckPermsPlayer now implements Permissible
- CondHasPermission and the shared hasPermission(CommandSender, String) helper check against Permissible instead of the concrete class
This means permission checks work against any Permissible implementation, not just LuckPermsPlayer, making it easier to embed this elsewhere or build on top of it without requiring LuckPerms specifically.