### PR TITLE
Don't require publishing credentials to build

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,10 +27,8 @@ subprojects {
 			maven {
 				url = uri("https://maven.hapily.me/snapshots")
 				credentials {
-					username = (project.findProperty("repoHapilyUsername") as? String)
-						?: throw GradleException("Missing global property 'repoHapilyUsername'")
-					password = (project.findProperty("repoHapilyPassword") as? String)
-						?: throw GradleException("Missing global property 'repoHapilyPassword'")
+					username = providers.gradleProperty("repoHapilyUsername").orNull
+					password = providers.gradleProperty("repoHapilyPassword").orNull
 				}
 			}
 		}

--- a/minestom/build.gradle.kts
+++ b/minestom/build.gradle.kts
@@ -82,10 +82,8 @@ publishing {
 		maven {
 			url = uri("https://maven.hapily.me/snapshots")
 			credentials {
-				username = (project.findProperty("repoHapilyUsername") as? String)
-					?: throw GradleException("Missing global property 'repoHapilyUsername'")
-				password = (project.findProperty("repoHapilyPassword") as? String)
-					?: throw GradleException("Missing global property 'repoHapilyPassword'")
+				username = providers.gradleProperty("repoHapilyUsername").orNull
+				password = providers.gradleProperty("repoHapilyPassword").orNull
 			}
 		}
 	}


### PR DESCRIPTION
### Description
The publishing credentials are read with a throw fallback at configuration time, so it fires on every task preventing tasks. Cloning the repo and running `gradlew build` fails with `Missing global property 'repoHapilyUsername'.`

This reads them through `providers.gradleProperty(...).orNull` so it can run without credentials.
