### PR TITLE
Fix reload command suggestions on trailing space

### DIFF
--- a/minestom/src/main/java/com/github/hapily04/skriptminestom/command/reload/ReloadCommand.java
+++ b/minestom/src/main/java/com/github/hapily04/skriptminestom/command/reload/ReloadCommand.java
@@ -91,7 +91,8 @@ public class ReloadCommand extends Command {
 	}
 
 	public static void initSuggestions(@NotNull Suggestion suggestion, String input, boolean enable) {
-		String scriptArg = input.split(" ")[2];
+		String[] tokens = input.split(" ");
+		String scriptArg = tokens.length > 2 ? tokens[2].replace("\0", "") : "";
 		File scripts = Skript.getInstance().getScriptsFolder();
 		String scriptsPathString = scripts.toPath().toString();
 		int scriptsPathLength = scriptsPathString.length();


### PR DESCRIPTION
`initSuggestions` doesn't strip the `\u0000` that `TabCompleteListener` appends when the input ends with a space, so `scriptArg` becomes `"\0"` and the `startsWith(scriptArg)` filter rejects every filename. `/skript reload ''` with nothing typed only suggests `all` and `config`. No scripts show until you type a character.