### PR TITLE
Prevent unhandled exceptions from killing the scheduler

### DIFF
--- a/common/src/main/java/org/bukkit/scheduler/BukkitSchedulerImpl.java
+++ b/common/src/main/java/org/bukkit/scheduler/BukkitSchedulerImpl.java
@@ -32,6 +32,10 @@ public class BukkitSchedulerImpl implements BukkitScheduler {
 		for (int taskID : tasks.keySet()) {
 			Task task = tasks.get(taskID);
 			if (task == null) continue; // Task was removed mid-tick
+			if (task.isCancelled()) {
+				tasks.remove(taskID);
+				continue;
+			}
 			task.ticksLeft--;
 
 			if (task.ticksLeft > 0) continue;
@@ -163,15 +167,24 @@ public class BukkitSchedulerImpl implements BukkitScheduler {
 	}
 
 	public boolean isCurrentlyRunning(int taskID) {
-		if (!tasks.containsKey(taskID))
+		Task task = tasks.get(taskID);
+		if (task == null)
 			return false;
 
-		Task task = tasks.get(taskID);
 		return task.isRepeating() || (!task.async && currentTask == task);
 	}
 
 	public void cancelTask(int taskID) {
-		tasks.remove(taskID).setCancelled(true);
+		Task task = tasks.remove(taskID);
+		if (task == null) {
+			for (Task pending : pendingTasks) {
+				if (pending.id != taskID) continue;
+				pendingTasks.remove(pending);
+				task = pending;
+				break;
+			}
+		}
+		if (task != null) task.setCancelled(true);
 	}
 
 	public <T> Future<T> callSyncMethod(Plugin plugin, Callable<T> task) {

--- a/common/src/main/java/org/bukkit/scheduler/BukkitSchedulerImpl.java
+++ b/common/src/main/java/org/bukkit/scheduler/BukkitSchedulerImpl.java
@@ -40,8 +40,13 @@ public class BukkitSchedulerImpl implements BukkitScheduler {
 
 			if (task.ticksLeft > 0) continue;
 			currentTask = task;
-			if (task.async) threadPool.submit(task.runnable);
-			else task.runnable.run();
+			try {
+				if (task.async) threadPool.submit(task.runnable);
+				else task.runnable.run();
+			} catch (Throwable t) {
+				Bukkit.getLogger().log(java.util.logging.Level.SEVERE,
+					"Task " + taskID + " from " + task.getOwner().getName() + " threw an exception", t);
+			}
 
 			currentTask = null;
 			task.ticksLeft = task.isRepeating() ? task.duration : task.delay;


### PR DESCRIPTION
`BukkitSchedulerImpl` has two current issues which can permanently disable the scheduler.
`cancelTask` calls `setCancelled` directly after `tasks.remove(taskID)`, which is null once the task has run. As `Task.cancel()` delegates to this method, cancelling a completed task throws a `NullPointerException`. Cancelling a task that has not yet moved out of the pending queue was also missed, leaving it scheduled to run regardless.

`tick()` runs task bodies with no exception handling, so anything thrown escapes and kills the thread running the scheduler. Every delay and repeating task then stops for the rest of the session, after a single stack trace.

Reproducible by cancelling a completed task from inside a scheduled task. A one tick heartbeat drops from about 100 runs per five seconds to 5, and does not recover. With both fixed it stays at 100. `isCurrentlyRunning` had the same unguarded lookup.