### PR TITLE
Synchronise Skript's scheduler with the server tick

### DIFF
--- a/common/src/main/java/org/bukkit/Bukkit.java
+++ b/common/src/main/java/org/bukkit/Bukkit.java
@@ -17,11 +17,13 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
 import java.util.UUID;
+import java.util.function.BooleanSupplier;
 import java.util.logging.Handler;
 import java.util.logging.LogRecord;
 
 public class Bukkit {
 	private static final Thread primaryThread = Thread.currentThread();
+	private static BooleanSupplier primaryThreadCheck = () -> Thread.currentThread().equals(primaryThread);
 	private static final PluginManager pluginManager = new SimplePluginManager();
 	private static final Logger trueLogger = LoggerFactory.getLogger(Bukkit.class);
 	private static final java.util.logging.Logger logger = generateBadLogger("Bukkit", trueLogger);
@@ -89,7 +91,11 @@ public class Bukkit {
 	}
 
 	public static boolean isPrimaryThread() {
-		return Thread.currentThread().equals(primaryThread);
+		return primaryThreadCheck.getAsBoolean();
+	}
+
+	public static void setPrimaryThreadCheck(BooleanSupplier check) {
+		Bukkit.primaryThreadCheck = check;
 	}
 
 	public static Thread getPrimaryThread() {

--- a/common/src/main/java/org/bukkit/scheduler/BukkitSchedulerImpl.java
+++ b/common/src/main/java/org/bukkit/scheduler/BukkitSchedulerImpl.java
@@ -12,6 +12,7 @@ import java.util.concurrent.*;
 import java.util.function.Consumer;
 
 public class BukkitSchedulerImpl implements BukkitScheduler {
+
 	// concurrenthashmap fixes concurrentmodificationexception from having a lot of events run at once
 	private final Map<Integer, Task> tasks = new ConcurrentHashMap<>();
 	private final Queue<Task> pendingTasks = new ConcurrentLinkedQueue<>();

--- a/common/src/main/java/org/bukkit/scheduler/BukkitSchedulerImpl.java
+++ b/common/src/main/java/org/bukkit/scheduler/BukkitSchedulerImpl.java
@@ -32,6 +32,10 @@ public class BukkitSchedulerImpl implements BukkitScheduler {
 		for (int taskID : tasks.keySet()) {
 			Task task = tasks.get(taskID);
 			if (task == null) continue; // Task was removed mid-tick
+			if (task.isCancelled()) {
+				tasks.remove(taskID);
+				continue;
+			}
 			task.ticksLeft--;
 
 			if (task.ticksLeft > 0) continue;
@@ -163,15 +167,24 @@ public class BukkitSchedulerImpl implements BukkitScheduler {
 	}
 
 	public boolean isCurrentlyRunning(int taskID) {
-		if (!tasks.containsKey(taskID))
+		Task task = tasks.get(taskID);
+		if (task == null)
 			return false;
 
-		Task task = tasks.get(taskID);
 		return task.isRepeating() || (!task.async && currentTask == task);
 	}
 
 	public void cancelTask(int taskID) {
-		tasks.remove(taskID).setCancelled(true);
+		Task task = tasks.remove(taskID);
+		if (task == null) {
+			for (Task pending : pendingTasks) {
+				if (pending.id != taskID) continue;
+				pendingTasks.remove(pending);
+				task = pending;
+				break;
+			}
+		}
+		if (task != null) task.setCancelled(true);
 	}
 
 	public <T> Future<T> callSyncMethod(Plugin plugin, Callable<T> task) {

--- a/common/src/main/java/org/bukkit/scheduler/BukkitSchedulerImpl.java
+++ b/common/src/main/java/org/bukkit/scheduler/BukkitSchedulerImpl.java
@@ -40,8 +40,13 @@ public class BukkitSchedulerImpl implements BukkitScheduler {
 
 			if (task.ticksLeft > 0) continue;
 			currentTask = task;
-			if (task.async) threadPool.submit(task.runnable);
-			else task.runnable.run();
+			try {
+				if (task.async) threadPool.submit(task.runnable);
+				else task.runnable.run();
+			} catch (Throwable t) {
+				Bukkit.getLogger().log(java.util.logging.Level.SEVERE,
+					"Task " + taskID + " from " + task.getOwner().getName() + " threw an exception", t);
+			}
 
 			currentTask = null;
 			task.ticksLeft = task.isRepeating() ? task.duration : task.delay;

--- a/minestom/src/main/java/com/github/hapily04/skriptminestom/SkriptMinestom.java
+++ b/minestom/src/main/java/com/github/hapily04/skriptminestom/SkriptMinestom.java
@@ -71,6 +71,7 @@ public class SkriptMinestom {
 	private static Properties properties;
 	private static LuckPerms luckPerms;
 	private static SparkMinestom spark;
+	private static volatile Thread schedulerThread;
 
 	static void main() {
 		properties = PropertyUtils.loadServerProperties();
@@ -137,8 +138,14 @@ public class SkriptMinestom {
 
 	@SuppressWarnings({"unchecked", "rawtypes"})
 	private static void initSkript() throws URISyntaxException {
-		Bukkit.setPrimaryThreadCheck(() -> Thread.currentThread() instanceof TickThread);
-		Bukkit.setTicker(tick -> MinecraftServer.getSchedulerManager().scheduleTask(tick, TaskSchedule.tick(1), TaskSchedule.tick(1))); // tick on minestom's thread
+		Bukkit.setPrimaryThreadCheck(() -> {
+			Thread current = Thread.currentThread();
+			return current instanceof TickThread || current == schedulerThread;
+		});
+		Bukkit.setTicker(tick -> MinecraftServer.getSchedulerManager().scheduleTask(() -> {
+			schedulerThread = Thread.currentThread();
+			tick.run();
+		}, TaskSchedule.tick(1), TaskSchedule.tick(1))); // tick on minestom's thread
 		Bukkit.setServer(new BukkitServer());
 		Bukkit.getScheduler(); // initialize scheduler
 

--- a/minestom/src/main/java/com/github/hapily04/skriptminestom/SkriptMinestom.java
+++ b/minestom/src/main/java/com/github/hapily04/skriptminestom/SkriptMinestom.java
@@ -44,6 +44,8 @@ import net.minestom.server.event.EventDispatcher;
 import net.minestom.server.event.EventNode;
 import net.minestom.server.event.GlobalEventHandler;
 import net.minestom.server.event.player.PlayerChatEvent;
+import net.minestom.server.thread.TickThread;
+import net.minestom.server.timer.TaskSchedule;
 import org.bukkit.Bukkit;
 import org.bukkit.event.Event;
 import org.bukkit.plugin.Plugin;
@@ -135,7 +137,8 @@ public class SkriptMinestom {
 
 	@SuppressWarnings({"unchecked", "rawtypes"})
 	private static void initSkript() throws URISyntaxException {
-		//Bukkit.setTicker(tick -> MinecraftServer.getSchedulerManager().scheduleTask(tick, TaskSchedule.tick(1), TaskSchedule.tick(1))); // tick on minestom's thread
+		Bukkit.setPrimaryThreadCheck(() -> Thread.currentThread() instanceof TickThread);
+		Bukkit.setTicker(tick -> MinecraftServer.getSchedulerManager().scheduleTask(tick, TaskSchedule.tick(1), TaskSchedule.tick(1))); // tick on minestom's thread
 		Bukkit.setServer(new BukkitServer());
 		Bukkit.getScheduler(); // initialize scheduler
 


### PR DESCRIPTION
The call that ticks Skript on Minestom's scheduler is commented out, and enabling it breaks. `isPrimaryThread()` compares against the thread that loaded `Bukkit`, so once the scheduler moves, scheduled work reports it is not on the primary thread. `Task.callSync` then queues work onto the scheduler and blocks the thread that has to run it. Script loading uses this path, so a load never finishes.

Checking for `TickThread` isn't enough either, as Minestom runs `TaskSchedule.tick()` work on a separate thread which is not a `TickThread`. The check now records the thread the ticker runs on, and treats that or a `TickThread` as primary.

The current default ticker is a `java.util.Timer` running on its own at 50ms, so delays don't align with the server tick. This aligns them and ensures code runs on the same ticker. This also fixes skript-reflect, where `EffRunSection` decides how to resume a trigger from `isPrimaryThread()` and so always resumes asynchronously today.

This builds on #15, which fixes the scheduler issues this change exposes. Its two commits are included here and will drop out of this diff once it merges.
