### PR TITLE
feat: minecraft tags

### DIFF
--- a/minestom/src/main/java/ch/njol/skript/conditions/CondIsTagged.java
+++ b/minestom/src/main/java/ch/njol/skript/conditions/CondIsTagged.java
@@ -1,0 +1,68 @@
+package ch.njol.skript.conditions;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.conditions.base.PropertyCondition;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Keywords;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.lang.Condition;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.util.MinecraftTag;
+import ch.njol.skript.util.TagType;
+import ch.njol.util.Kleenean;
+import net.minestom.server.registry.RegistryKey;
+import org.bukkit.event.Event;
+import org.jetbrains.annotations.Nullable;
+
+@Name("Is Tagged")
+@Description("""
+	Checks whether an item, block, entity or entity type is tagged with the given minecraft tag.
+	Matching is done by namespaced key, so an oak log is tagged with both the item and the block version of "logs".""")
+@Examples("""
+	if player's tool is tagged with item tag "planks":
+		send "that's a plank!"
+
+	on block break:
+		if event-block is tagged with tag "mineable/pickaxe":
+			cancel event""")
+@Keywords({"tag", "tagged", "minecraft tag"})
+public class CondIsTagged extends Condition {
+
+	static {
+		Skript.registerCondition(CondIsTagged.class,
+			"%items/blocks/entitytypes/entities% (is|are) tagged (as|with) %minecrafttags%",
+			"%items/blocks/entitytypes/entities% (isn't|is not|aren't|are not) tagged (as|with) %minecrafttags%");
+	}
+
+	private Expression<?> values;
+	private Expression<MinecraftTag> tags;
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public boolean init(Expression<?>[] expressions, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
+		values = expressions[0];
+		tags = (Expression<MinecraftTag>) expressions[1];
+		setNegated(matchedPattern == 1);
+		return true;
+	}
+
+	@Override
+	public boolean check(Event event) {
+		return values.check(event,
+			value -> tags.check(event, tag -> matches(value, tag)), isNegated());
+	}
+
+	@Override
+	public String toString(@Nullable Event event, boolean debug) {
+		return PropertyCondition.toString(this, PropertyCondition.PropertyType.BE, event, debug, values,
+			"tagged as " + tags.toString(event, debug));
+	}
+
+	private static boolean matches(Object value, MinecraftTag<?> tag) {
+		RegistryKey<?> key = TagType.keyOf(value);
+		return key != null && tag.contains(key);
+	}
+
+}

--- a/minestom/src/main/java/ch/njol/skript/conditions/CondIsTagged.java
+++ b/minestom/src/main/java/ch/njol/skript/conditions/CondIsTagged.java
@@ -22,7 +22,7 @@ import org.jetbrains.annotations.Nullable;
 	Matching is done by namespaced key, so an oak log is tagged with both the item and the block version of "logs".""")
 @Examples("""
 	if player's tool is tagged with item tag "planks":
-		send "that's a plank!"
+		send "that's a plank!" to player
 
 	on block break:
 		if event-block is tagged with tag "mineable/pickaxe":

--- a/minestom/src/main/java/ch/njol/skript/expressions/ExprTag.java
+++ b/minestom/src/main/java/ch/njol/skript/expressions/ExprTag.java
@@ -1,0 +1,91 @@
+package ch.njol.skript.expressions;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.doc.*;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.ExpressionType;
+import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.util.SimpleExpression;
+import ch.njol.skript.util.MinecraftTag;
+import ch.njol.skript.util.TagType;
+import ch.njol.util.Kleenean;
+import net.kyori.adventure.key.Key;
+import net.minestom.server.registry.RegistryKey;
+import net.minestom.server.registry.RegistryTag;
+import org.bukkit.event.Event;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+@Name("Tag")
+@Description("""
+	A minecraft tag, used to group items, blocks or entity types together.
+	Tags are written as "namespace:value"; if the namespace is left out, "minecraft" is used.
+	Without a type, every registry is searched, so a name shared by an item and a block tag returns both.""")
+@Examples("""
+	set {_tag} to minecraft tag "logs"
+	set {_tag} to block tag "mineable/pickaxe"
+	set {_tags::*} to item tags "planks" and "slabs"
+	broadcast tag contents of entity type tag "skeletons\"""")
+@Keywords({"tag", "minecraft tag", "registry"})
+public class ExprTag extends SimpleExpression<MinecraftTag> {
+
+	static {
+		Skript.registerExpression(ExprTag.class, MinecraftTag.class, ExpressionType.COMBINED,
+			"[the] [minecraft] [" + TagType.getFullPattern() + "] tag[s] %strings%");
+	}
+
+	private Expression<String> names;
+	@Nullable
+	private TagType<?> type;
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public boolean init(Expression<?>[] expressions, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
+		names = (Expression<String>) expressions[0];
+		if (parseResult.mark != 0) type = TagType.getType(parseResult.mark - 1);
+		return true;
+	}
+
+	@Override
+	protected MinecraftTag[] get(Event event) {
+		List<TagType<?>> types = type == null ? TagType.getTypes() : List.of(type);
+		List<MinecraftTag<?>> tags = new ArrayList<>();
+		for (String name : names.getArray(event)) {
+			String full = name.toLowerCase(Locale.ENGLISH);
+			if (!full.contains(":")) full = "minecraft:" + full;
+			if (!Key.parseable(full)) continue;
+			Key key = Key.key(full);
+			for (TagType<?> type : types) {
+				MinecraftTag<?> tag = lookup(type, key);
+				if (tag != null) tags.add(tag);
+			}
+		}
+		return tags.toArray(new MinecraftTag[0]);
+	}
+
+	@Override
+	public boolean isSingle() {
+		return names.isSingle() && type != null;
+	}
+
+	@Override
+	public Class<? extends MinecraftTag> getReturnType() {
+		return MinecraftTag.class;
+	}
+
+	@Override
+	public String toString(@Nullable Event event, boolean debug) {
+		return (type == null ? "" : type.getName() + " ") + "tag " + names.toString(event, debug);
+	}
+
+	@Nullable
+	private static <T extends RegistryKey<T>> MinecraftTag<T> lookup(TagType<T> type, Key key) {
+		RegistryTag<T> tag = type.getRegistry().getTag(key);
+		if (tag == null) return null;
+		return new MinecraftTag<>(tag, type);
+	}
+
+}

--- a/minestom/src/main/java/ch/njol/skript/expressions/ExprTagContents.java
+++ b/minestom/src/main/java/ch/njol/skript/expressions/ExprTagContents.java
@@ -1,0 +1,67 @@
+package ch.njol.skript.expressions;
+
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Keywords;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.expressions.base.PropertyExpression;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.util.SimpleExpression;
+import ch.njol.skript.util.MinecraftTag;
+import ch.njol.util.Kleenean;
+import org.bukkit.event.Event;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+@Name("Tag Contents")
+@Description("""
+	Every value held by a minecraft tag.
+	An item tag returns items, a block tag returns blocks, and an entity type tag returns entity types.""")
+@Examples("""
+	broadcast tag contents of block tag "logs"
+	set {_planks::*} to tag values of item tag "planks\"""")
+@Keywords({"tag", "contents", "minecraft tag"})
+public class ExprTagContents extends SimpleExpression<Object> {
+
+	static {
+		PropertyExpression.register(ExprTagContents.class, Object.class, "tag (contents|values)", "minecrafttags");
+	}
+
+	private Expression<MinecraftTag> tags;
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public boolean init(Expression<?>[] expressions, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
+		tags = (Expression<MinecraftTag>) expressions[0];
+		return true;
+	}
+
+	@Override
+	protected Object[] get(Event event) {
+		List<Object> values = new ArrayList<>();
+		for (MinecraftTag<?> tag : tags.getArray(event)) {
+			Collections.addAll(values, tag.contents());
+		}
+		return values.toArray();
+	}
+
+	@Override
+	public boolean isSingle() {
+		return false;
+	}
+
+	@Override
+	public Class<?> getReturnType() {
+		return Object.class;
+	}
+
+	@Override
+	public String toString(@Nullable Event event, boolean debug) {
+		return "tag contents of " + tags.toString(event, debug);
+	}
+
+}

--- a/minestom/src/main/java/ch/njol/skript/expressions/ExprTagKey.java
+++ b/minestom/src/main/java/ch/njol/skript/expressions/ExprTagKey.java
@@ -1,0 +1,39 @@
+package ch.njol.skript.expressions;
+
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Keywords;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.expressions.base.SimplePropertyExpression;
+import ch.njol.skript.util.MinecraftTag;
+
+@Name("Tag Namespaced Key")
+@Description("""
+	The namespaced key of a minecraft tag, written as "namespace:value".
+	Tags loaded from vanilla data always use the "minecraft" namespace.""")
+@Examples("""
+	broadcast namespaced key of block tag "logs"
+	set {_keys::*} to namespaced keys of tags of player's tool""")
+@Keywords({"tag", "key", "namespace", "minecraft tag"})
+public class ExprTagKey extends SimplePropertyExpression<MinecraftTag, String> {
+
+	static {
+		register(ExprTagKey.class, String.class, "[namespace[d]] key[s]", "minecrafttags");
+	}
+
+	@Override
+	public String convert(MinecraftTag from) {
+		return from.key().asString();
+	}
+
+	@Override
+	public Class<? extends String> getReturnType() {
+		return String.class;
+	}
+
+	@Override
+	protected String getPropertyName() {
+		return "namespaced key";
+	}
+
+}

--- a/minestom/src/main/java/ch/njol/skript/expressions/ExprTagsOf.java
+++ b/minestom/src/main/java/ch/njol/skript/expressions/ExprTagsOf.java
@@ -1,0 +1,86 @@
+package ch.njol.skript.expressions;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Keywords;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.ExpressionType;
+import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.util.SimpleExpression;
+import ch.njol.skript.util.MinecraftTag;
+import ch.njol.skript.util.TagType;
+import ch.njol.util.Kleenean;
+import net.minestom.server.registry.RegistryKey;
+import net.minestom.server.registry.RegistryTag;
+import org.bukkit.event.Event;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Name("Tags Of")
+@Description("""
+	Every minecraft tag an item, block, entity or entity type belongs to.
+	Without a kind, every registry is searched, so an oak log returns both its item and its block tags.""")
+@Examples("""
+	broadcast tags of dirt
+	set {_tags::*} to block tags of event-block
+	if player's tool's item tags contains item tag "planks":
+		send "holding a plank\"""")
+@Keywords({"tag", "tags of", "minecraft tag"})
+public class ExprTagsOf extends SimpleExpression<MinecraftTag> {
+
+	static {
+		Skript.registerExpression(ExprTagsOf.class, MinecraftTag.class, ExpressionType.PROPERTY,
+			"[all [of] [the]] [" + TagType.getFullPattern() + "] tags of %items/blocks/entitytypes/entities%",
+			"%items/blocks/entitytypes/entities%'[s] [" + TagType.getFullPattern() + "] tags");
+	}
+
+	private Expression<?> values;
+	@Nullable
+	private TagType<?> type;
+
+	@Override
+	public boolean init(Expression<?>[] expressions, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
+		values = expressions[0];
+		if (parseResult.mark != 0) type = TagType.getType(parseResult.mark - 1);
+		return true;
+	}
+
+	@Override
+	protected MinecraftTag[] get(Event event) {
+		List<TagType<?>> types = type == null ? TagType.getTypes() : List.of(type);
+		List<MinecraftTag<?>> tags = new ArrayList<>();
+		for (Object value : values.getArray(event)) {
+			RegistryKey<?> key = TagType.keyOf(value);
+			if (key == null) continue;
+			for (TagType<?> searchType : types) collect(searchType, key, tags);
+		}
+		return tags.toArray(new MinecraftTag[0]);
+	}
+
+	@Override
+	public boolean isSingle() {
+		return false;
+	}
+
+	@Override
+	public Class<? extends MinecraftTag> getReturnType() {
+		return MinecraftTag.class;
+	}
+
+	@Override
+	public String toString(@Nullable Event event, boolean debug) {
+		return (type == null ? "" : type.getName() + " ") + "tags of " + values.toString(event, debug);
+	}
+
+	private static <T extends RegistryKey<T>> void collect(TagType<T> type, RegistryKey<?> key, List<MinecraftTag<?>> into) {
+		for (RegistryTag<T> tag : type.getRegistry().tags()) {
+			MinecraftTag<T> minecraftTag = new MinecraftTag<>(tag, type);
+			if (minecraftTag.contains(key)) into.add(minecraftTag);
+		}
+	}
+
+}

--- a/minestom/src/main/java/ch/njol/skript/expressions/ExprTagsOf.java
+++ b/minestom/src/main/java/ch/njol/skript/expressions/ExprTagsOf.java
@@ -28,7 +28,7 @@ import java.util.List;
 	broadcast tags of dirt
 	set {_tags::*} to block tags of event-block
 	if player's tool's item tags contains item tag "planks":
-		send "holding a plank\"""")
+		send "holding a plank" to player""")
 @Keywords({"tag", "tags of", "minecraft tag"})
 public class ExprTagsOf extends SimpleExpression<MinecraftTag> {
 

--- a/minestom/src/main/java/ch/njol/skript/expressions/ExprTagsOfType.java
+++ b/minestom/src/main/java/ch/njol/skript/expressions/ExprTagsOfType.java
@@ -1,0 +1,75 @@
+package ch.njol.skript.expressions;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Keywords;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.ExpressionType;
+import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.util.SimpleExpression;
+import ch.njol.skript.util.MinecraftTag;
+import ch.njol.skript.util.TagType;
+import ch.njol.util.Kleenean;
+import net.minestom.server.registry.RegistryKey;
+import net.minestom.server.registry.RegistryTag;
+import org.bukkit.event.Event;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Name("All Tags of a Type")
+@Description("""
+	Every minecraft tag the server knows about, optionally limited to one kind.
+	Without a kind, the item, block and entity type registries are all included.""")
+@Examples("""
+	broadcast size of all block tags
+	set {_entityTags::*} to all entity type tags""")
+@Keywords({"tag", "tags", "minecraft tag", "registry"})
+public class ExprTagsOfType extends SimpleExpression<MinecraftTag> {
+
+	static {
+		Skript.registerExpression(ExprTagsOfType.class, MinecraftTag.class, ExpressionType.SIMPLE,
+			"[all [of] [the]] [minecraft] " + TagType.getFullPattern() + " tags",
+			"all [of] [the] [minecraft] tags");
+	}
+
+	@Nullable
+	private TagType<?> type;
+
+	@Override
+	public boolean init(Expression<?>[] expressions, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
+		if (matchedPattern == 0) type = TagType.getType(parseResult.mark - 1);
+		return true;
+	}
+
+	@Override
+	protected MinecraftTag[] get(Event event) {
+		List<TagType<?>> types = type == null ? TagType.getTypes() : List.of(type);
+		List<MinecraftTag<?>> tags = new ArrayList<>();
+		for (TagType<?> searchType : types) collect(searchType, tags);
+		return tags.toArray(new MinecraftTag[0]);
+	}
+
+	@Override
+	public boolean isSingle() {
+		return false;
+	}
+
+	@Override
+	public Class<? extends MinecraftTag> getReturnType() {
+		return MinecraftTag.class;
+	}
+
+	@Override
+	public String toString(@Nullable Event event, boolean debug) {
+		return "all " + (type == null ? "" : type.getName() + " ") + "tags";
+	}
+
+	private static <T extends RegistryKey<T>> void collect(TagType<T> type, List<MinecraftTag<?>> into) {
+		for (RegistryTag<T> tag : type.getRegistry().tags()) into.add(new MinecraftTag<>(tag, type));
+	}
+
+}

--- a/minestom/src/main/java/ch/njol/skript/util/MinecraftTag.java
+++ b/minestom/src/main/java/ch/njol/skript/util/MinecraftTag.java
@@ -1,0 +1,50 @@
+package ch.njol.skript.util;
+
+import net.kyori.adventure.key.Key;
+import net.minestom.server.registry.Registry;
+import net.minestom.server.registry.RegistryKey;
+import net.minestom.server.registry.RegistryTag;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+public record MinecraftTag<T extends RegistryKey<T>>(RegistryTag<T> tag, TagType<T> type) {
+
+	public Key key() {
+		return tag.key().key();
+	}
+
+	@SuppressWarnings("unchecked")
+	public boolean contains(RegistryKey<?> value) {
+		return tag.contains((RegistryKey<T>) value);
+	}
+
+	public Object[] contents() {
+		Registry<T> registry = type.getRegistry();
+		List<Object> values = new ArrayList<>(tag.size());
+		for (RegistryKey<T> key : tag) {
+			T value = registry.get(key);
+			if (value != null) values.add(type.toSkript(value));
+		}
+		return values.toArray();
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) return true;
+		if (!(object instanceof MinecraftTag<?> other)) return false;
+		return type == other.type && key().equals(other.key());
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(type, key());
+	}
+
+	@Override
+	public String toString() {
+		return key().asString();
+	}
+
+}

--- a/minestom/src/main/java/ch/njol/skript/util/TagType.java
+++ b/minestom/src/main/java/ch/njol/skript/util/TagType.java
@@ -1,0 +1,83 @@
+package ch.njol.skript.util;
+
+import net.minestom.server.MinecraftServer;
+import net.minestom.server.entity.Entity;
+import net.minestom.server.entity.EntityType;
+import net.minestom.server.instance.block.Block;
+import net.minestom.server.item.ItemStack;
+import net.minestom.server.item.Material;
+import net.minestom.server.registry.Registries;
+import net.minestom.server.registry.Registry;
+import net.minestom.server.registry.RegistryKey;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+import java.util.function.Function;
+
+public final class TagType<T extends RegistryKey<T>> {
+
+	public static final TagType<Material> ITEMS =
+		new TagType<>("item", "item", Registries::material, material -> new Item(ItemStack.of(material)));
+	public static final TagType<Block> BLOCKS =
+		new TagType<>("block", "block", Registries::blocks, block -> block);
+	public static final TagType<EntityType> ENTITIES =
+		new TagType<>("entity [type]", "entity type", Registries::entityType, entityType -> entityType);
+
+	private static final List<TagType<?>> TYPES = List.of(ITEMS, BLOCKS, ENTITIES);
+
+	private final String pattern;
+	private final String name;
+	private final Function<Registries, Registry<T>> registry;
+	private final Function<T, ?> toSkript;
+
+	private TagType(String pattern, String name, Function<Registries, Registry<T>> registry, Function<T, ?> toSkript) {
+		this.pattern = pattern;
+		this.name = name;
+		this.registry = registry;
+		this.toSkript = toSkript;
+	}
+
+	public Registry<T> getRegistry() {
+		return registry.apply(MinecraftServer.getRegistries());
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public Object toSkript(T value) {
+		return toSkript.apply(value);
+	}
+
+	@Override
+	public String toString() {
+		return name;
+	}
+
+	@Nullable
+	public static RegistryKey<?> keyOf(Object value) {
+		if (value instanceof Item item) return item.getItem().material();
+		if (value instanceof Block block) return block;
+		if (value instanceof EntityType entityType) return entityType;
+		if (value instanceof Entity entity) return entity.getEntityType();
+		return null;
+	}
+
+	public static List<TagType<?>> getTypes() {
+		return TYPES;
+	}
+
+	public static TagType<?> getType(int index) {
+		return TYPES.get(index);
+	}
+
+	public static String getFullPattern() {
+		StringBuilder builder = new StringBuilder("(");
+		for (int i = 0; i < TYPES.size(); i++) {
+			if (i != 0) builder.append('|');
+			builder.append(i + 1).append(':').append(TYPES.get(i).pattern);
+		}
+		return builder.append(')').toString();
+	}
+
+}

--- a/minestom/src/main/java/com/github/hapily04/skriptminestom/registration/MinestomClasses.java
+++ b/minestom/src/main/java/com/github/hapily04/skriptminestom/registration/MinestomClasses.java
@@ -2241,6 +2241,32 @@ public class MinestomClasses {
 				}
 			}));
 
+		Classes.registerClass(new ClassInfo<>(MinecraftTag.class, "minecrafttag")
+			.user("minecraft ?tags?")
+			.name("Minecraft Tag")
+			.description("""
+				A tag used to group items, blocks or entity types, such as 'minecraft:logs'.
+				Tags have a namespace and a value, written as "namespace:value". Obtain them with the 'tag' expression.""")
+			.usage("<namespace>:<value>")
+			.examples("minecraft tag \"logs\"")
+			.defaultExpression(new EventValueExpression<>(MinecraftTag.class))
+			.parser(new Parser<>() {
+				@Override
+				public boolean canParse(@NotNull ParseContext context) {
+					return false;
+				}
+
+				@Override
+				public @NotNull String toString(@NotNull MinecraftTag o, int flags) {
+					return toVariableNameString(o);
+				}
+
+				@Override
+				public @NotNull String toVariableNameString(@NotNull MinecraftTag o) {
+					return o.type().getName() + " tag " + o.key().asString();
+				}
+			}));
+
 		/*
 		 * Converters
 		 */
@@ -2349,6 +2375,7 @@ public class MinestomClasses {
 		//Comparators.registerComparator(Item.class, Slot.class, (o1, o2) -> Relation.get(o1.getItem().isSimilar(o2.getItem())));
 		Comparators.registerComparator(Item.class, Item.class, (o1, o2) -> Relation.get(o1.getItem().equals(o2.getItem())));
 		Comparators.registerComparator(Block.class, Block.class, (o1, o2) -> Relation.get(o1.compare(o2)));
+		Comparators.registerComparator(MinecraftTag.class, MinecraftTag.class, (o1, o2) -> Relation.get(o1.equals(o2)));
 		Comparators.registerComparator(Item.class, Block.class, (o1, o2) -> {
 			ItemStack item = o1.getItem();
 			Material material = item.material();


### PR DESCRIPTION
### Description
<!--- Describe your changes here. --->
Adds minecraft tags like `#minecraft:logs`. All six of Skript's tag elements are ported. 

```
[the] [minecraft] [item|block|entity type] tag[s] %strings%
%items/blocks/entitytypes/entities% (is|are) tagged (as|with) %minecrafttags%
[the] tag (contents|values) of %minecrafttags%
[all [of] [the]] [item|block|entity type] tags of %items/blocks/entitytypes/entities%
[the] [namespace[d]] key[s] of %minecrafttags%
[all [of] [the]] [minecraft] [item|block|entity type] tags
```
```
set {_tag} to block tag "logs"

on block break:
    if event-block is tagged with block tag "mineable/pickaxe":
        send "you need a pickaxe for that"
```
- Scoped to vanilla tags only and no `custom`/`datapack` origins. 
---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
