### PR TITLE
feat/entity-velocity-event

### DIFF
--- a/minestom/src/main/java/ch/njol/skript/events/SimpleEvents.java
+++ b/minestom/src/main/java/ch/njol/skript/events/SimpleEvents.java
@@ -80,6 +80,14 @@ public class SimpleEvents {
 		Skript.registerEvent("Entity Equip", SimpleEvent.class, EntityEquipWrapper.class, "[entity] equip")
 			.description("Called when an equipment slot changes on an entity.")
 			.examples("on entity equip:");
+		Skript.registerEvent("Entity Velocity", SimpleEvent.class, EntityVelocityWrapper.class, "entity velocity [change]")
+			.description("""
+				Called when an entity's velocity is about to change.
+				Cancelling this keeps the entity's current velocity.""")
+			.examples("""
+				on entity velocity:
+					if event-entity is a player:
+						set event-vector to event-vector * 2 # double every push a player receives""");
 		Skript.registerEvent("Player Move", SimpleEvent.class, PlayerMoveWrapper.class, "[player] move")
 			.description("Called when a player attempts to move")
 			.examples("on player move:");

--- a/minestom/src/main/java/ch/njol/skript/events/wrapper/EntityVelocityWrapper.java
+++ b/minestom/src/main/java/ch/njol/skript/events/wrapper/EntityVelocityWrapper.java
@@ -1,0 +1,23 @@
+package ch.njol.skript.events.wrapper;
+
+import ch.njol.skript.classes.Changer;
+import ch.njol.skript.events.wrapper.marker.EntityInstanceEventMarker;
+import ch.njol.skript.registrations.EventValues;
+import net.minestom.server.coordinate.Vec;
+import net.minestom.server.event.entity.EntityVelocityEvent;
+import org.skriptlang.skript.bukkit.lang.eventvalue.EventValue;
+
+public class EntityVelocityWrapper extends EventWrapper<EntityVelocityEvent> implements EntityInstanceEventMarker {
+
+	static {
+		EventValues.registerEventValue(EventValue.builder(EntityVelocityWrapper.class, Vec.class)
+			.getter(from -> from.event.getVelocity())
+			.registerChanger(Changer.ChangeMode.SET, (event, value) -> event.event.setVelocity(value))
+			.build());
+	}
+
+	public EntityVelocityWrapper(EntityVelocityEvent event) {
+		super(event);
+	}
+
+}


### PR DESCRIPTION
### Description
Adds an `entity velocity` event, wrapping Minestom's `EntityVelocityEvent`.
Ex) `on entity velocity [change]:`
<!--- Describe your changes here. --->

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
