### PR TITLE
Fix skript-minestom crashing when run from compiled classes

### DIFF
--- a/common/src/main/java/ch/njol/skript/Skript.java
+++ b/common/src/main/java/ch/njol/skript/Skript.java
@@ -55,6 +55,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.lang.Thread.UncaughtExceptionHandler;
 import java.lang.reflect.Method;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -64,6 +65,7 @@ import java.util.*;
 import java.util.Map.Entry;
 import java.util.logging.Level;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipException;
 import java.util.zip.ZipFile;
@@ -250,6 +252,23 @@ public final class Skript extends JavaPlugin implements Listener {
 		return addonsFolder;
 	}
 
+	private Collection<String> getResourceEntries() throws IOException {
+		URL url = getClass().getResource("/config.sk");
+		if (url == null)
+			return Collections.emptyList();
+		Path root;
+		try {
+			root = Paths.get(url.toURI()).getParent();
+		} catch (URISyntaxException | IllegalArgumentException e) {
+			return Collections.emptyList();
+		}
+		try (Stream<Path> paths = Files.walk(root)) {
+			return paths.filter(Files::isRegularFile)
+				.map(path -> root.relativize(path).toString().replace(File.separatorChar, '/'))
+				.collect(Collectors.toList());
+		}
+	}
+
 	@Override
 	public void onEnable() {
 		updateMinecraftVersion();
@@ -297,35 +316,44 @@ public final class Skript extends JavaPlugin implements Listener {
 					populateLanguageFiles = true;
 				}
 
-				f = new ZipFile(getFile());
-				for (ZipEntry e : new EnumerationIterable<ZipEntry>(f.entries())) {
-					if (e.isDirectory())
-						continue;
+				File source = getFile();
+				Collection<String> entries;
+				if (source != null && source.isFile()) {
+					f = new ZipFile(source);
+					entries = new ArrayList<>();
+					for (ZipEntry e : new EnumerationIterable<ZipEntry>(f.entries())) {
+						if (!e.isDirectory())
+							entries.add(e.getName());
+					}
+				} else {
+					entries = getResourceEntries();
+				}
+				for (String entry : entries) {
 					File saveTo = null;
-					if (populateExamples && e.getName().startsWith(SCRIPTSFOLDER + "/")) {
-						String fileName = e.getName().substring(e.getName().indexOf("/") + 1);
+					if (populateExamples && entry.startsWith(SCRIPTSFOLDER + "/")) {
+						String fileName = entry.substring(entry.indexOf("/") + 1);
 						// All example scripts must be disabled for jar security.
 						if (!fileName.startsWith(ScriptLoader.DISABLED_SCRIPT_PREFIX))
 							fileName = ScriptLoader.DISABLED_SCRIPT_PREFIX + fileName;
 						saveTo = new File(scriptsFolder, fileName);
 					} else if (populateLanguageFiles
-							&& e.getName().startsWith("lang/")
-							&& !e.getName().endsWith("default.lang")) {
-						String fileName = e.getName().substring(e.getName().lastIndexOf("/") + 1);
+							&& entry.startsWith("lang/")
+							&& !entry.endsWith("default.lang")) {
+						String fileName = entry.substring(entry.lastIndexOf("/") + 1);
 						saveTo = new File(lang, fileName);
-					} else if (e.getName().equals("config.sk")) {
+					} else if (entry.equals("config.sk")) {
 						if (!config.exists())
 							saveTo = config;
-//					} else if (e.getName().startsWith("aliases-") && e.getName().endsWith(".sk") && !e.getName().contains("/")) {
-//						File af = new File(getDataFolder(), e.getName());
+//					} else if (entry.startsWith("aliases-") && entry.endsWith(".sk") && !entry.contains("/")) {
+//						File af = new File(getDataFolder(), entry);
 //						if (!af.exists())
 //							saveTo = af;
-					} else if (e.getName().startsWith("features.sk")) {
+					} else if (entry.startsWith("features.sk")) {
 						if (!features.exists())
 							saveTo = features;
 					}
 					if (saveTo != null) {
-						InputStream in = f.getInputStream(e);
+						InputStream in = f != null ? f.getInputStream(f.getEntry(entry)) : getResource(entry);
 						try {
 							assert in != null;
 							FileUtils.save(in, saveTo);

--- a/common/src/main/java/org/bukkit/plugin/PluginClassLoader.java
+++ b/common/src/main/java/org/bukkit/plugin/PluginClassLoader.java
@@ -78,6 +78,8 @@ public class PluginClassLoader extends URLClassLoader {
 			return description;
 
 		URL resource = findResource("plugin.yml"); // Only searches this loader’s URLs
+		if (resource == null && file.isDirectory())
+			resource = getResource("plugin.yml");
 		if (resource == null) {
 			Bukkit.getBetterLogger().warn("Found JAR '{}' in the plugins folder without a plugin.yml file.", file.getName());
 			return null;

--- a/common/src/main/java/org/skriptlang/skript/util/ClassLoader.java
+++ b/common/src/main/java/org/skriptlang/skript/util/ClassLoader.java
@@ -87,6 +87,10 @@ public class ClassLoader {
 	 * @see #loadClasses(Class, JarFile)
 	 */
 	public void loadClasses(Class<?> source, File jarFile) {
+		if (jarFile == null || !jarFile.isFile()) {
+			loadClasses(source);
+			return;
+		}
 		try (JarFile jar = new JarFile(jarFile)) {
 			loadClasses(source, jar);
 		} catch (IOException e) {


### PR DESCRIPTION
Running skript-minestom through an IDE currently crashes. The code source is a directory instead of a jar, so `PluginClassLoader` never finds `plugin.yml`. `loadPlugin` returns null and `initSkript` NPEs on `skript.setEnabled(true)`.

`plugin.yml` now falls back to the classpath when the code source is a directory. Same problem in `Skript.onEnable`, which reads its own jar with `ZipFile` to generate config.sk, features.sk, lang/ and the examples. On a directory that throws, nothing gets written, and it dies with "`Cannot load variables before the config`". It lists the resource directory instead in that case.

`loadClasses` was throwing a `JarFile` at that same directory and printing `Failed to access jar file: ... (Access is denied)` every run before falling back, so it goes straight to the fallback now.
