### PR TITLE
feat: item flags

### DIFF
--- a/minestom/src/main/java/ch/njol/skript/expressions/ExprItemFlags.java
+++ b/minestom/src/main/java/ch/njol/skript/expressions/ExprItemFlags.java
@@ -1,0 +1,90 @@
+package ch.njol.skript.expressions;
+
+import ch.njol.skript.classes.Changer;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Keywords;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.expressions.base.PropertyExpression;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.util.Item;
+import ch.njol.skript.util.ItemFlag;
+import ch.njol.util.Kleenean;
+import ch.njol.util.coll.CollectionUtils;
+import org.bukkit.event.Event;
+import org.eclipse.jdt.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+@Name("Item Flags")
+@Description("""
+	The item flags of an item, which are the parts of its tooltip that are hidden.
+	A flag is only listed if everything it hides is currently hidden.""")
+@Examples("""
+	add hide enchants to item flags of player's tool
+	remove hide dye from the item flags of {_item}
+	set item flags of {_item} to hide attributes and hide unbreakable
+	clear item flags of {_item}
+
+	if item flags of player's tool contains hide attributes:
+		send "your tool's attributes are hidden!\"""")
+@Keywords({"item", "flag", "hide", "tooltip"})
+public class ExprItemFlags extends PropertyExpression<Item, ItemFlag> {
+
+	static {
+		register(ExprItemFlags.class, ItemFlag.class, "item flag[s]", "items");
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public boolean init(Expression<?>[] expressions, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
+		setExpr((Expression<? extends Item>) expressions[0]);
+		return true;
+	}
+
+	@Override
+	protected ItemFlag[] get(Event event, Item[] source) {
+		List<ItemFlag> flags = new ArrayList<>();
+		for (Item item : source) {
+			for (ItemFlag flag : ItemFlag.getFlags(item)) {
+				if (!flags.contains(flag)) flags.add(flag);
+			}
+		}
+		return flags.toArray(new ItemFlag[0]);
+	}
+
+	@Override
+	public Class<?> @Nullable [] acceptChange(Changer.ChangeMode mode) {
+		return switch (mode) {
+			case SET, ADD, REMOVE, DELETE, RESET -> CollectionUtils.array(ItemFlag[].class);
+			default -> null;
+		};
+	}
+
+	@Override
+	public void change(Event event, @Nullable Object[] delta, Changer.ChangeMode mode) throws UnsupportedOperationException {
+		ItemFlag[] flags = delta == null ? new ItemFlag[0] : Arrays.copyOf(delta, delta.length, ItemFlag[].class);
+		for (Item item : getExpr().getArray(event)) {
+			switch (mode) {
+				case SET -> ItemFlag.set(item, flags);
+				case ADD -> ItemFlag.add(item, true, flags);
+				case REMOVE -> ItemFlag.remove(item, flags);
+				case DELETE, RESET -> ItemFlag.set(item);
+			}
+		}
+	}
+
+	@Override
+	public Class<? extends ItemFlag> getReturnType() {
+		return ItemFlag.class;
+	}
+
+	@Override
+	public String toString(@Nullable Event event, boolean debug) {
+		return "item flags of " + getExpr().toString(event, debug);
+	}
+
+}

--- a/minestom/src/main/java/ch/njol/skript/expressions/ExprItemWithFlags.java
+++ b/minestom/src/main/java/ch/njol/skript/expressions/ExprItemWithFlags.java
@@ -1,62 +1,65 @@
 package ch.njol.skript.expressions;
 
+import ch.njol.skript.Skript;
 import ch.njol.skript.doc.Description;
 import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Keywords;
 import ch.njol.skript.doc.Name;
 import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.ExpressionType;
 import ch.njol.skript.lang.SkriptParser;
 import ch.njol.skript.lang.util.SimpleExpression;
 import ch.njol.skript.util.Item;
 import ch.njol.skript.util.ItemFlag;
 import ch.njol.util.Kleenean;
-import net.kyori.adventure.nbt.CompoundBinaryTag;
-import net.minestom.server.item.ItemStack;
 import org.bukkit.event.Event;
 import org.eclipse.jdt.annotation.Nullable;
 
-
 @Name("Item With Flags")
-@Description("An item with specific item flags applied.")
-@Examples("# set {_item} to stone with the hide attributes item flag")
+@Description("An item with the given item flags applied, hiding those parts of its tooltip.")
+@Examples("""
+	give player diamond sword with the hide attributes item flag
+	set {_potion} to potion of healing with all item flags
+	set {_i} to stone with the item flags hide dye and hide enchants""")
+@Keywords({"item", "flag", "hide", "tooltip"})
 public class ExprItemWithFlags extends SimpleExpression<Item> {
 
 	static {
-		/*Skript.registerExpression(ExprItemWithFlags.class, Item.class, ExpressionType.COMBINED,
+		Skript.registerExpression(ExprItemWithFlags.class, Item.class, ExpressionType.COMBINED,
 			"%items% with [the] item flag[s] %itemflags%",
 			"%items% with [the] %itemflags% item flag[s]",
-			"%items% with all [the] item flags");*/
+			"%items% with all [the] item flags");
 	}
 
-	private Expression<Item> item;
-	private Expression<ItemFlag> flags;
+	private Expression<Item> items;
+	private @Nullable Expression<ItemFlag> flags;
 
 	@SuppressWarnings("unchecked")
 	@Override
 	public boolean init(Expression<?>[] expressions, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
-		item = (Expression<Item>) expressions[0];
-		flags = (Expression<ItemFlag>) expressions[1];
+		items = (Expression<Item>) expressions[0];
+		// the third pattern applies every flag, so it has no item flag expression of its own
+		flags = matchedPattern == 2 ? null : (Expression<ItemFlag>) expressions[1];
 		return true;
 	}
 
 	@Override
-	protected @Nullable Item[] get(Event event) {
-		//NBTCompound nbt = this.flags.getSingle(event);
-		Item item = this.item.getSingle(event);
-		//item.getItem().withoutExtraTooltip()
-		//if (nbt == null || item == null) return new Item[0];
-		item = item.copy();
-		//item.getItem().withoutExtraTooltip()
-		//CompoundBinaryTag incomingCompound = nbt.getCompound();
-		CompoundBinaryTag itemCompound = item.getItem().toItemNBT();
-		//itemCompound = NBTUtils.mergeItemNBT(itemCompound, incomingCompound, item.getItem());
-		ItemStack newItemStack = ItemStack.fromItemNBT(itemCompound);
-		item.modify(_ -> newItemStack);
-		return new Item[]{item};
+	protected Item @Nullable [] get(Event event) {
+		ItemFlag[] flags = this.flags == null ? ItemFlag.values() : this.flags.getArray(event);
+		if (flags.length == 0) return new Item[0];
+		Item[] items = this.items.getArray(event);
+		Item[] flagged = new Item[items.length];
+		for (int i = 0; i < items.length; i++) {
+			Item item = items[i].copy();
+			ItemFlag.add(item, false, flags);
+			flagged[i] = item;
+		}
+		return flagged;
 	}
 
 	@Override
 	public boolean isSingle() {
-		return true;
+		return items.isSingle();
 	}
 
 	@Override
@@ -66,8 +69,8 @@ public class ExprItemWithFlags extends SimpleExpression<Item> {
 
 	@Override
 	public String toString(@Nullable Event event, boolean debug) {
-		return item.toString(event, debug) + " with item flag " + flags.toString(event, debug);
+		if (flags == null) return items.toString(event, debug) + " with all item flags";
+		return items.toString(event, debug) + " with the item flags " + flags.toString(event, debug);
 	}
 
 }
-

--- a/minestom/src/main/java/ch/njol/skript/util/ItemFlag.java
+++ b/minestom/src/main/java/ch/njol/skript/util/ItemFlag.java
@@ -1,27 +1,105 @@
 package ch.njol.skript.util;
 
 import net.minestom.server.component.DataComponent;
+import net.minestom.server.component.DataComponents;
+import net.minestom.server.item.ItemStack;
+import net.minestom.server.item.component.TooltipDisplay;
 
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * A group of {@link DataComponent}s that can be hidden from an item's tooltip at once.
+ * <p>
+ * Minestom has no item flags of its own; hiding is done through
+ * {@link DataComponents#TOOLTIP_DISPLAY}, which holds the set of components that should not be
+ * rendered. These constants mirror the item flags Skript users are already familiar with and map
+ * each of them onto the components it hides.
+ */
 public enum ItemFlag {
 
-	/*
-	                    DataComponents.BANNER_PATTERNS, DataComponents.BEES, DataComponents.BLOCK_ENTITY_DATA,
-                    DataComponents.BLOCK_STATE, DataComponents.BUNDLE_CONTENTS, DataComponents.CHARGED_PROJECTILES,
-                    DataComponents.CONTAINER, DataComponents.CONTAINER_LOOT, DataComponents.FIREWORK_EXPLOSION,
-                    DataComponents.FIREWORKS, DataComponents.INSTRUMENT, DataComponents.MAP_ID,
-                    DataComponents.PAINTING_VARIANT, DataComponents.POT_DECORATIONS, DataComponents.POTION_CONTENTS,
-                    DataComponents.TROPICAL_FISH_PATTERN, DataComponents.WRITTEN_BOOK_CONTENT,
-                    DataComponents.UNBREAKABLE, DataComponents.ATTRIBUTE_MODIFIERS
+	HIDE_ENCHANTS(DataComponents.ENCHANTMENTS),
+	HIDE_ATTRIBUTES(DataComponents.ATTRIBUTE_MODIFIERS),
+	HIDE_UNBREAKABLE(DataComponents.UNBREAKABLE),
+	HIDE_DESTROYS(DataComponents.CAN_BREAK),
+	HIDE_PLACED_ON(DataComponents.CAN_PLACE_ON),
+	HIDE_DYE(DataComponents.DYED_COLOR),
+	HIDE_ARMOR_TRIM(DataComponents.TRIM),
+	HIDE_STORED_ENCHANTS(DataComponents.STORED_ENCHANTMENTS),
+	HIDE_ADDITIONAL_TOOLTIP(DataComponents.BANNER_PATTERNS, DataComponents.BEES,
+		DataComponents.BLOCK_ENTITY_DATA, DataComponents.BLOCK_STATE, DataComponents.BUNDLE_CONTENTS,
+		DataComponents.CHARGED_PROJECTILES, DataComponents.CONTAINER, DataComponents.CONTAINER_LOOT,
+		DataComponents.FIREWORK_EXPLOSION, DataComponents.FIREWORKS, DataComponents.INSTRUMENT,
+		DataComponents.MAP_ID, DataComponents.PAINTING_VARIANT, DataComponents.POT_DECORATIONS,
+		DataComponents.POTION_CONTENTS, DataComponents.TROPICAL_FISH_PATTERN,
+		DataComponents.WRITTEN_BOOK_CONTENT);
+
+	private final Set<DataComponent<?>> dataComponents;
+
+	ItemFlag(DataComponent<?>... dataComponents) {
+		this.dataComponents = Set.of(dataComponents);
+	}
+
+	public Set<DataComponent<?>> getDataComponents() {
+		return dataComponents;
+	}
+
+	public static void add(Item to, boolean notify, ItemFlag... flags) {
+		Set<DataComponent<?>> hidden = new HashSet<>(getHiddenComponents(to.getItem()));
+		for (ItemFlag flag : flags)
+			hidden.addAll(flag.dataComponents);
+		apply(to, hidden, notify);
+	}
+
+	public static void set(Item to, ItemFlag... flags) {
+		Set<DataComponent<?>> hidden = new HashSet<>();
+		for (ItemFlag flag : flags)
+			hidden.addAll(flag.dataComponents);
+		apply(to, hidden, true);
+	}
+
+	public static void remove(Item from, ItemFlag... flags) {
+		Set<DataComponent<?>> hidden = new HashSet<>(getHiddenComponents(from.getItem()));
+		for (ItemFlag flag : flags)
+			hidden.removeAll(flag.dataComponents);
+		apply(from, hidden, true);
+	}
+
+	/**
+	 * @return every flag whose components are all hidden on the given item.
 	 */
-	;
-
-	private final DataComponent<?> dataComponent;
-
-	ItemFlag(DataComponent<?> dataComponent) {
-		this.dataComponent = dataComponent;
+	public static ItemFlag[] getFlags(Item item) {
+		Set<DataComponent<?>> hidden = getHiddenComponents(item.getItem());
+		if (hidden.isEmpty()) return new ItemFlag[0];
+		List<ItemFlag> flags = new ArrayList<>();
+		for (ItemFlag flag : values()) {
+			if (hidden.containsAll(flag.dataComponents)) flags.add(flag);
+		}
+		return flags.toArray(new ItemFlag[0]);
 	}
 
-	public DataComponent<?> getDataComponent() {
-		return dataComponent;
+	public static Set<DataComponent<?>> getHiddenComponents(ItemStack item) {
+		TooltipDisplay display = item.get(DataComponents.TOOLTIP_DISPLAY);
+		return display == null ? Set.of() : display.hiddenComponents();
 	}
+
+	/**
+	 * Replaces the hidden components of the item, leaving the rest of its tooltip display
+	 * (currently only {@link TooltipDisplay#hideTooltip()}) untouched.
+	 */
+	private static void apply(Item item, Set<DataComponent<?>> hidden, boolean notify) {
+		item.modify(stack -> {
+			TooltipDisplay display = stack.get(DataComponents.TOOLTIP_DISPLAY, TooltipDisplay.EMPTY);
+			TooltipDisplay newDisplay = new TooltipDisplay(display.hideTooltip(), hidden);
+			TooltipDisplay prototype = stack.material().prototype()
+				.get(DataComponents.TOOLTIP_DISPLAY, TooltipDisplay.EMPTY);
+			// don't leave an explicit override behind if it's what the material does anyway,
+			// otherwise an item that had all of its flags removed wouldn't equal a plain one
+			if (newDisplay.equals(prototype)) return stack.reset(DataComponents.TOOLTIP_DISPLAY);
+			return stack.with(DataComponents.TOOLTIP_DISPLAY, newDisplay);
+		}, notify);
+	}
+
 }

--- a/minestom/src/main/java/com/github/hapily04/skriptminestom/registration/MinestomClasses.java
+++ b/minestom/src/main/java/com/github/hapily04/skriptminestom/registration/MinestomClasses.java
@@ -1213,9 +1213,7 @@ public class MinestomClasses {
 		Classes.registerClass(new EnumClassInfo<>(ItemFlag.class, "itemflag")
 			.user("item ?flags?")
 			.name("Item Flag")
-			.description("""
-				A part of an item's tooltip that can be hidden.
-				Possible values: hide enchants, hide attributes, hide unbreakable, hide destroys, hide placed on, hide dye, hide armor trim, hide stored enchants, hide additional tooltip.""")
+			.description("A part of an item's tooltip that can be hidden.")
 			.examples("""
 				give player diamond sword with the hide attributes item flag
 				add hide enchants to item flags of player's tool"""));

--- a/minestom/src/main/java/com/github/hapily04/skriptminestom/registration/MinestomClasses.java
+++ b/minestom/src/main/java/com/github/hapily04/skriptminestom/registration/MinestomClasses.java
@@ -1210,6 +1210,15 @@ public class MinestomClasses {
 					return false;
 				}
 			}));
+		Classes.registerClass(new EnumClassInfo<>(ItemFlag.class, "itemflag")
+			.user("item ?flags?")
+			.name("Item Flag")
+			.description("""
+				A part of an item's tooltip that can be hidden.
+				Possible values: hide enchants, hide attributes, hide unbreakable, hide destroys, hide placed on, hide dye, hide armor trim, hide stored enchants, hide additional tooltip.""")
+			.examples("""
+				give player diamond sword with the hide attributes item flag
+				add hide enchants to item flags of player's tool"""));
 		Classes.registerClass(new ClassInfo<>(Direction.class, "direction")
 			.user("directions?")
 			.name("Direction")


### PR DESCRIPTION
### Description
Adds item flag syntax

Implements item flags, filling in the `ItemFlag` enum and `ExprItemWithFlags` stubs that
were already in the tree, and adding a settable `item flags of %items%` expression
alongside them.
<!--- Describe your changes here. --->

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
