### PR TITLE
fix: run event listeners lowest-first

### DIFF
--- a/common/src/main/java/org/bukkit/event/HandlerList.java
+++ b/common/src/main/java/org/bukkit/event/HandlerList.java
@@ -53,7 +53,7 @@ public class HandlerList {
 			int priorityA = a.getPriority().ordinal();
 			int priorityB = b.getPriority().ordinal();
 
-			return Integer.compare(priorityB, priorityA);
+			return Integer.compare(priorityA, priorityB);
 		});
 		return baked;
 	}


### PR DESCRIPTION
HandlerList.bake() sorts descending by priority ordinal, so listeners fire MONITOR -> HIGHEST -> HIGH -> NORMAL -> LOW -> LOWEST. That's inverted from Bukkit, and from StructEvent's own javadoc example which says lowest is called first and highest last.

So anything reading final event state at monitor reads it before every other handler has run, and anything cancelling at lowest cancels after the handlers meant to override it already went.

How to reproduce:

```
on join with priority lowest:
	broadcast "lowest"

on join with priority normal:
	broadcast "normal"

on join with priority monitor:
	broadcast "monitor"
```

```
before: monitor, normal, lowest
after:  lowest, normal, monitor
```

Flipped the comparator to ascending. Order verified by registering one RegisteredListener per priority in shuffled order and dumping the baked list:

```
registration: [LOW, LOWEST, HIGHEST, MONITOR, HIGH, NORMAL]
before:       [MONITOR, HIGHEST, HIGH, NORMAL, LOW, LOWEST]
after:        [LOWEST, LOW, NORMAL, HIGH, HIGHEST, MONITOR]
```