### PR TITLE
Log Skript warnings at WARN instead of INFO

### DIFF
--- a/common/src/main/java/ch/njol/skript/log/SkriptLogger.java
+++ b/common/src/main/java/ch/njol/skript/log/SkriptLogger.java
@@ -180,7 +180,7 @@ public abstract class SkriptLogger {
 			}
 		}
 		entry.logged();
-		LoggerUtils.log(LOGGER, Level.INFO, "<skript_minestom_tag> " + entry.toFormattedString());
+		LoggerUtils.log(LOGGER, entry.getLevel(), "<skript_minestom_tag> " + entry.toFormattedString());
 	}
 	
 	public static void logAll(Collection<LogEntry> entries) {

--- a/common/src/main/java/org/bukkit/util/LoggerUtils.java
+++ b/common/src/main/java/org/bukkit/util/LoggerUtils.java
@@ -12,14 +12,14 @@ public class LoggerUtils {
 	public static void log(Logger logger, Level level, String msg, Exception e) {
 		msg = ansify(msg);
 		if (level.equals(Level.SEVERE)) logger.error(msg, e);
-		else if (level.equals(Level.WARNING)) logger.info(msg, e);
+		else if (level.equals(Level.WARNING)) logger.warn(msg, e);
 		else logger.info(msg, e);
 	}
 
 	public static void log(Logger logger, Level level, String msg) {
 		msg = ansify(msg);
 		if (level.equals(Level.SEVERE)) logger.error(msg);
-		else if (level.equals(Level.WARNING)) logger.info(msg);
+		else if (level.equals(Level.WARNING)) logger.warn(msg);
 		else logger.info(msg);
 	}
 


### PR DESCRIPTION
Every Skript parse warning comes out at INFO.

That matters if you raise the console's log level above INFO, or if you search logs for
WARN and ERROR to find what went wrong. Either way the warnings are invisible, and the
only way to spot one is to read every line of a startup that looks clean.

SkriptLogger.log(LogEntry) throws away the entry's own level and passes Level.INFO, so
nothing arrives at the logger as a warning in the first place. LoggerUtils.log then sends
Level.WARNING to logger.info in both overloads, which is the same as the else branch
under it.

To Reproduce:

on script load:
	broadcast "a", "b", "c"

Before:
[23:55:02 INFO] [Skript-Minestom] Line 2: (warn.sk)
    List is missing 'and' or 'or', defaulting to 'and': "a", "b", "c"

After:
[23:56:50 WARN] [Skript-Minestom] Line 2: (warn.sk)
    List is missing 'and' or 'or', defaulting to 'and': "a", "b", "c"

Errors still come out at ERROR. I put a bad line in a second script next to the warning
and both showed at the right level.
