### PR TITLE
Cancel events that implement CancellableEvent without an EventWrapper

### DIFF
--- a/minestom/src/main/java/ch/njol/skript/effects/EffCancelEvent.java
+++ b/minestom/src/main/java/ch/njol/skript/effects/EffCancelEvent.java
@@ -56,8 +56,11 @@ public class EffCancelEvent extends Effect {
 
 	@Override
 	public void execute(final Event e) {
-		net.minestom.server.event.Event trueEvent = ((EventWrapper<?>) e).getEvent();
-		if (trueEvent instanceof CancellableEvent cancellable) cancellable.setCancelled(cancel);
+		if (e instanceof EventWrapper<?> wrapper) {
+			if (wrapper.getEvent() instanceof CancellableEvent cancellable) cancellable.setCancelled(cancel);
+		} else if (e instanceof CancellableEvent cancellable) {
+			cancellable.setCancelled(cancel);
+		}
 	}
 
 	@Override
@@ -67,6 +70,7 @@ public class EffCancelEvent extends Effect {
 
 	public static boolean isCancellable(Class<? extends Event> event) {
 		if (Cancellable.class.isAssignableFrom(event)) return true;
+		if (CancellableEvent.class.isAssignableFrom(event)) return true;
 		Class<? extends net.minestom.server.event.Event> minestomEventClass = getMinestomEventType(event);
 		return minestomEventClass != null && CancellableEvent.class.isAssignableFrom(minestomEventClass);
 	}


### PR DESCRIPTION
`EffCancelEvent.isCancellable` recognises two shapes: a class implementing Bukkit's `Cancellable`, or an `EventWrapper<E>` whose `E` implements Minestom's `CancellableEvent`. `EffectCommandEvent` is neither, as it extends `Event` and implements `CancellableEvent` itself, so `isCancellable` returns false and `cancel event` is rejected at parse time with `An on effect command event cannot be cancelled`.

The rest of the trigger still loads, so a script that cancels an effect command runs every other line and the command executes anyway. `parseAndExecuteEffectCommand` checks `effectCommandEvent.isCancelled()` before parsing the effect, so the guard is already there, nothing can set it.

This adds `CancellableEvent.class.isAssignableFrom(event)` to `isCancellable`, and stops `execute` assuming the event is an `EventWrapper`, as `EffectCommandEvent` is not one and the unconditional cast would throw.

Reproduce with `enable effect commands: true`:

```
on effect command:
	broadcast "EFFCMDTEST-1-FIRED"
	cancel event
	broadcast "EFFCMDTEST-2-CANCELLED"
```

Then `!broadcast "EFFCMDTEST-3-RAN"` from the console. Before, the parse error at load and all three markers print. After, no parse error, `-1` and `-2` print and `-3-RAN` does not. `on server list ping: cancel event` still returns 0 bytes to a ping on both builds, so the `EventWrapper` path is unchanged.
