### PR TITLE
feat: item tooltip hiding syntax

### DIFF
--- a/minestom/src/main/java/ch/njol/skript/conditions/CondItemTooltipHidden.java
+++ b/minestom/src/main/java/ch/njol/skript/conditions/CondItemTooltipHidden.java
@@ -17,8 +17,9 @@ import org.eclipse.jdt.annotation.Nullable;
 @Name("Item Tooltip Hidden")
 @Description("""
 	Whether the tooltip of an item is hidden.
-	An item only counts as having its additional tooltip hidden if every part of it is hidden, \
-	so an item that merely has its entire tooltip hidden doesn't match.""")
+	The additional tooltip covers the same parts as the hide additional tooltip item flag, and an \
+	item only counts as having it hidden if every one of those parts is hidden, so an item \
+	that merely has its entire tooltip hidden doesn't match.""")
 @Examples("""
 	if player's tool has its entire tooltip hidden:
 		send "you can't see what that is!"

--- a/minestom/src/main/java/ch/njol/skript/conditions/CondItemTooltipHidden.java
+++ b/minestom/src/main/java/ch/njol/skript/conditions/CondItemTooltipHidden.java
@@ -1,0 +1,63 @@
+package ch.njol.skript.conditions;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Keywords;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.lang.Condition;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.util.Item;
+import ch.njol.skript.util.ItemTooltip;
+import ch.njol.util.Kleenean;
+import org.bukkit.event.Event;
+import org.eclipse.jdt.annotation.Nullable;
+
+@Name("Item Tooltip Hidden")
+@Description("""
+	Whether the tooltip of an item is hidden.
+	An item only counts as having its additional tooltip hidden if every part of it is hidden, \
+	so an item that merely has its entire tooltip hidden doesn't match.""")
+@Examples("""
+	if player's tool has its entire tooltip hidden:
+		send "you can't see what that is!"
+
+	if {_item} doesn't have its additional tooltip hidden:
+		set {_item} to {_item} without additional tooltip""")
+@Keywords({"item", "tooltip", "hide"})
+public class CondItemTooltipHidden extends Condition {
+
+	static {
+		Skript.registerCondition(CondItemTooltipHidden.class,
+			"%items% (has|have) [its|their] (entire|:additional) tool[ ]tip hidden",
+			"%items% (doesn't|does not|don't|do not) have [its|their] (entire|:additional) tool[ ]tip hidden");
+	}
+
+	private Expression<Item> items;
+
+	private boolean additional;
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public boolean init(Expression<?>[] expressions, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
+		items = (Expression<Item>) expressions[0];
+		additional = parseResult.hasTag("additional");
+		setNegated(matchedPattern == 1);
+		return true;
+	}
+
+	@Override
+	public boolean check(Event event) {
+		return items.check(event,
+			item -> additional ? ItemTooltip.isAdditionalHidden(item) : ItemTooltip.isEntireHidden(item),
+			isNegated());
+	}
+
+	@Override
+	public String toString(@Nullable Event event, boolean debug) {
+		return items.toString(event, debug) + (isNegated() ? " doesn't have " : " has ")
+			+ (additional ? "additional" : "entire") + " tooltip hidden";
+	}
+
+}

--- a/minestom/src/main/java/ch/njol/skript/conditions/CondItemTooltipHidden.java
+++ b/minestom/src/main/java/ch/njol/skript/conditions/CondItemTooltipHidden.java
@@ -31,8 +31,8 @@ public class CondItemTooltipHidden extends Condition {
 
 	static {
 		Skript.registerCondition(CondItemTooltipHidden.class,
-			"%items% (has|have) [its|their] (entire|:additional) tool[ ]tip hidden",
-			"%items% (doesn't|does not|don't|do not) have [its|their] (entire|:additional) tool[ ]tip hidden");
+			"%items% (has|have) [its|their] (entire|:additional) tool[ ]tip[s] hidden",
+			"%items% (doesn't|does not|don't|do not) have [its|their] (entire|:additional) tool[ ]tip[s] hidden");
 	}
 
 	private Expression<Item> items;
@@ -57,8 +57,7 @@ public class CondItemTooltipHidden extends Condition {
 
 	@Override
 	public String toString(@Nullable Event event, boolean debug) {
-		return items.toString(event, debug) + (isNegated() ? " doesn't have " : " has ")
-			+ (additional ? "additional" : "entire") + " tooltip hidden";
+		return items.toString(event, debug) + (isNegated() ? " doesn't have " : " has ") + (additional ? "additional" : "entire") + " tooltip hidden";
 	}
 
 }

--- a/minestom/src/main/java/ch/njol/skript/expressions/ExprItemWithoutTooltip.java
+++ b/minestom/src/main/java/ch/njol/skript/expressions/ExprItemWithoutTooltip.java
@@ -19,8 +19,8 @@ import org.eclipse.jdt.annotation.Nullable;
 @Description("""
 	An item with its tooltip hidden, or shown again.
 	The entire tooltip hides everything, including the name and lore of the item.
-	The additional tooltip hides everything but the name and lore, such as potion effects, \
-	banner patterns, attribute modifiers and the contents of a container.""")
+	The additional tooltip hides the same parts as the hide additional tooltip item flag, \
+	such as potion effects, banner patterns and the contents of a container.""")
 @Examples("""
 	give player stone without entire tooltip
 	give player potion of healing without its additional tooltip

--- a/minestom/src/main/java/ch/njol/skript/expressions/ExprItemWithoutTooltip.java
+++ b/minestom/src/main/java/ch/njol/skript/expressions/ExprItemWithoutTooltip.java
@@ -1,0 +1,82 @@
+package ch.njol.skript.expressions;
+
+import ch.njol.skript.Skript;
+import ch.njol.skript.doc.Description;
+import ch.njol.skript.doc.Examples;
+import ch.njol.skript.doc.Keywords;
+import ch.njol.skript.doc.Name;
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.ExpressionType;
+import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.util.SimpleExpression;
+import ch.njol.skript.util.Item;
+import ch.njol.skript.util.ItemTooltip;
+import ch.njol.util.Kleenean;
+import org.bukkit.event.Event;
+import org.eclipse.jdt.annotation.Nullable;
+
+@Name("Item Without Tooltip")
+@Description("""
+	An item with its tooltip hidden, or shown again.
+	The entire tooltip hides everything, including the name and lore of the item.
+	The additional tooltip hides everything but the name and lore, such as potion effects, \
+	banner patterns, attribute modifiers and the contents of a container.""")
+@Examples("""
+	give player stone without entire tooltip
+	give player potion of healing without its additional tooltip
+	set {_item} to {_hidden item} with entire tooltip""")
+@Keywords({"item", "tooltip", "hide"})
+public class ExprItemWithoutTooltip extends SimpleExpression<Item> {
+
+	static {
+		Skript.registerExpression(ExprItemWithoutTooltip.class, Item.class, ExpressionType.COMBINED,
+			"%items% with[:out] [the|its|their] (entire|:additional) tool[ ]tip");
+	}
+
+	private Expression<Item> items;
+
+	private boolean hidden;
+	private boolean additional;
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public boolean init(Expression<?>[] expressions, int matchedPattern, Kleenean isDelayed, SkriptParser.ParseResult parseResult) {
+		items = (Expression<Item>) expressions[0];
+		hidden = parseResult.hasTag("out");
+		additional = parseResult.hasTag("additional");
+		return true;
+	}
+
+	@Override
+	protected Item @Nullable [] get(Event event) {
+		Item[] items = this.items.getArray(event);
+		Item[] modified = new Item[items.length];
+		for (int i = 0; i < items.length; i++) {
+			Item item = items[i].copy();
+			if (additional) {
+				ItemTooltip.setAdditionalHidden(item, hidden);
+			} else {
+				ItemTooltip.setEntireHidden(item, hidden);
+			}
+			modified[i] = item;
+		}
+		return modified;
+	}
+
+	@Override
+	public boolean isSingle() {
+		return items.isSingle();
+	}
+
+	@Override
+	public Class<? extends Item> getReturnType() {
+		return Item.class;
+	}
+
+	@Override
+	public String toString(@Nullable Event event, boolean debug) {
+		return items.toString(event, debug) + (hidden ? " without " : " with ")
+			+ (additional ? "additional" : "entire") + " tooltip";
+	}
+
+}

--- a/minestom/src/main/java/ch/njol/skript/expressions/ExprItemWithoutTooltip.java
+++ b/minestom/src/main/java/ch/njol/skript/expressions/ExprItemWithoutTooltip.java
@@ -30,7 +30,7 @@ public class ExprItemWithoutTooltip extends SimpleExpression<Item> {
 
 	static {
 		Skript.registerExpression(ExprItemWithoutTooltip.class, Item.class, ExpressionType.COMBINED,
-			"%items% with[:out] [the|its|their] (entire|:additional) tool[ ]tip");
+			"%items% with[:out] [the|its|their] (entire|:additional) tool[ ]tip[s]");
 	}
 
 	private Expression<Item> items;
@@ -53,11 +53,8 @@ public class ExprItemWithoutTooltip extends SimpleExpression<Item> {
 		Item[] modified = new Item[items.length];
 		for (int i = 0; i < items.length; i++) {
 			Item item = items[i].copy();
-			if (additional) {
-				ItemTooltip.setAdditionalHidden(item, hidden);
-			} else {
-				ItemTooltip.setEntireHidden(item, hidden);
-			}
+			if (additional) ItemTooltip.setAdditionalHidden(item, hidden);
+			else ItemTooltip.setEntireHidden(item, hidden);
 			modified[i] = item;
 		}
 		return modified;
@@ -75,8 +72,7 @@ public class ExprItemWithoutTooltip extends SimpleExpression<Item> {
 
 	@Override
 	public String toString(@Nullable Event event, boolean debug) {
-		return items.toString(event, debug) + (hidden ? " without " : " with ")
-			+ (additional ? "additional" : "entire") + " tooltip";
+		return items.toString(event, debug) + (hidden ? " without " : " with ") + (additional ? "additional" : "entire") + " tooltip";
 	}
 
 }

--- a/minestom/src/main/java/ch/njol/skript/util/ItemFlag.java
+++ b/minestom/src/main/java/ch/njol/skript/util/ItemFlag.java
@@ -48,22 +48,25 @@ public enum ItemFlag {
 
 	public static void add(Item to, boolean notify, ItemFlag... flags) {
 		Set<DataComponent<?>> hidden = new HashSet<>(getHiddenComponents(to.getItem()));
-		for (ItemFlag flag : flags)
+		for (ItemFlag flag : flags) {
 			hidden.addAll(flag.dataComponents);
+		}
 		apply(to, hidden, notify);
 	}
 
 	public static void set(Item to, ItemFlag... flags) {
 		Set<DataComponent<?>> hidden = new HashSet<>();
-		for (ItemFlag flag : flags)
+		for (ItemFlag flag : flags) {
 			hidden.addAll(flag.dataComponents);
+		}
 		apply(to, hidden, true);
 	}
 
 	public static void remove(Item from, ItemFlag... flags) {
 		Set<DataComponent<?>> hidden = new HashSet<>(getHiddenComponents(from.getItem()));
-		for (ItemFlag flag : flags)
+		for (ItemFlag flag : flags) {
 			hidden.removeAll(flag.dataComponents);
+		}
 		apply(from, hidden, true);
 	}
 

--- a/minestom/src/main/java/ch/njol/skript/util/ItemFlag.java
+++ b/minestom/src/main/java/ch/njol/skript/util/ItemFlag.java
@@ -81,8 +81,7 @@ public enum ItemFlag {
 	}
 
 	public static Set<DataComponent<?>> getHiddenComponents(ItemStack item) {
-		TooltipDisplay display = item.get(DataComponents.TOOLTIP_DISPLAY);
-		return display == null ? Set.of() : display.hiddenComponents();
+		return ItemTooltip.getDisplay(item).hiddenComponents();
 	}
 
 	/**
@@ -90,16 +89,7 @@ public enum ItemFlag {
 	 * (currently only {@link TooltipDisplay#hideTooltip()}) untouched.
 	 */
 	private static void apply(Item item, Set<DataComponent<?>> hidden, boolean notify) {
-		item.modify(stack -> {
-			TooltipDisplay display = stack.get(DataComponents.TOOLTIP_DISPLAY, TooltipDisplay.EMPTY);
-			TooltipDisplay newDisplay = new TooltipDisplay(display.hideTooltip(), hidden);
-			TooltipDisplay prototype = stack.material().prototype()
-				.get(DataComponents.TOOLTIP_DISPLAY, TooltipDisplay.EMPTY);
-			// don't leave an explicit override behind if it's what the material does anyway,
-			// otherwise an item that had all of its flags removed wouldn't equal a plain one
-			if (newDisplay.equals(prototype)) return stack.reset(DataComponents.TOOLTIP_DISPLAY);
-			return stack.with(DataComponents.TOOLTIP_DISPLAY, newDisplay);
-		}, notify);
+		ItemTooltip.modify(item, display -> new TooltipDisplay(display.hideTooltip(), hidden), notify);
 	}
 
 }

--- a/minestom/src/main/java/ch/njol/skript/util/ItemTooltip.java
+++ b/minestom/src/main/java/ch/njol/skript/util/ItemTooltip.java
@@ -1,0 +1,87 @@
+package ch.njol.skript.util;
+
+import net.minestom.server.component.DataComponent;
+import net.minestom.server.component.DataComponents;
+import net.minestom.server.item.ItemStack;
+import net.minestom.server.item.component.TooltipDisplay;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.UnaryOperator;
+
+/**
+ * Hiding of an item's tooltip through {@link DataComponents#TOOLTIP_DISPLAY}.
+ * <p>
+ * {@link ItemStack#withoutExtraTooltip()} replaces the whole component, which would drop any other
+ * hiding already applied to the item, so the tooltip display is edited in place here instead.
+ */
+public final class ItemTooltip {
+
+	/**
+	 * The components that append the additional part of an item's tooltip, meaning everything
+	 * besides its name and lore. Mirrors the set Minestom hides in
+	 * {@link ItemStack#withoutExtraTooltip()}.
+	 */
+	private static final Set<DataComponent<?>> ADDITIONAL_COMPONENTS = Set.of(
+		DataComponents.BANNER_PATTERNS, DataComponents.BEES, DataComponents.BLOCK_ENTITY_DATA,
+		DataComponents.BLOCK_STATE, DataComponents.BUNDLE_CONTENTS, DataComponents.CHARGED_PROJECTILES,
+		DataComponents.CONTAINER, DataComponents.CONTAINER_LOOT, DataComponents.FIREWORK_EXPLOSION,
+		DataComponents.FIREWORKS, DataComponents.INSTRUMENT, DataComponents.MAP_ID,
+		DataComponents.PAINTING_VARIANT, DataComponents.POT_DECORATIONS, DataComponents.POTION_CONTENTS,
+		DataComponents.TROPICAL_FISH_PATTERN, DataComponents.WRITTEN_BOOK_CONTENT,
+		DataComponents.UNBREAKABLE, DataComponents.ATTRIBUTE_MODIFIERS);
+
+	private ItemTooltip() { }
+
+	/**
+	 * Hides or shows the entire tooltip of an item, leaving the components it hides individually
+	 * untouched.
+	 */
+	public static void setEntireHidden(Item item, boolean hidden) {
+		apply(item, display -> new TooltipDisplay(hidden, display.hiddenComponents()));
+	}
+
+	/**
+	 * Hides or shows everything but the name and lore of an item, leaving the rest of its tooltip
+	 * display untouched.
+	 */
+	public static void setAdditionalHidden(Item item, boolean hidden) {
+		apply(item, display -> {
+			Set<DataComponent<?>> hiddenComponents = new HashSet<>(display.hiddenComponents());
+			if (hidden) {
+				hiddenComponents.addAll(ADDITIONAL_COMPONENTS);
+			} else {
+				hiddenComponents.removeAll(ADDITIONAL_COMPONENTS);
+			}
+			return new TooltipDisplay(display.hideTooltip(), hiddenComponents);
+		});
+	}
+
+	public static boolean isEntireHidden(Item item) {
+		return getDisplay(item.getItem()).hideTooltip();
+	}
+
+	/**
+	 * @return whether every component of the additional tooltip is hidden. An item that only has its
+	 * entire tooltip hidden doesn't count, as showing the tooltip again would reveal them.
+	 */
+	public static boolean isAdditionalHidden(Item item) {
+		return getDisplay(item.getItem()).hiddenComponents().containsAll(ADDITIONAL_COMPONENTS);
+	}
+
+	private static TooltipDisplay getDisplay(DataComponent.Holder holder) {
+		return holder.get(DataComponents.TOOLTIP_DISPLAY, TooltipDisplay.EMPTY);
+	}
+
+	private static void apply(Item item, UnaryOperator<TooltipDisplay> modifyFunction) {
+		item.modify(stack -> {
+			TooltipDisplay display = modifyFunction.apply(getDisplay(stack));
+			TooltipDisplay prototype = getDisplay(stack.material().prototype());
+			// don't leave an explicit override behind if it's what the material does anyway,
+			// otherwise an item that got its tooltip back wouldn't equal a plain one
+			if (display.equals(prototype)) return stack.reset(DataComponents.TOOLTIP_DISPLAY);
+			return stack.with(DataComponents.TOOLTIP_DISPLAY, display);
+		});
+	}
+
+}

--- a/minestom/src/main/java/ch/njol/skript/util/ItemTooltip.java
+++ b/minestom/src/main/java/ch/njol/skript/util/ItemTooltip.java
@@ -2,59 +2,24 @@ package ch.njol.skript.util;
 
 import net.minestom.server.component.DataComponent;
 import net.minestom.server.component.DataComponents;
-import net.minestom.server.item.ItemStack;
 import net.minestom.server.item.component.TooltipDisplay;
 
-import java.util.HashSet;
-import java.util.Set;
 import java.util.function.UnaryOperator;
 
-/**
- * Hiding of an item's tooltip through {@link DataComponents#TOOLTIP_DISPLAY}.
- * <p>
- * {@link ItemStack#withoutExtraTooltip()} replaces the whole component, which would drop any other
- * hiding already applied to the item, so the tooltip display is edited in place here instead.
- */
 public final class ItemTooltip {
-
-	/**
-	 * The components that append the additional part of an item's tooltip, meaning everything
-	 * besides its name and lore. Mirrors the set Minestom hides in
-	 * {@link ItemStack#withoutExtraTooltip()}.
-	 */
-	private static final Set<DataComponent<?>> ADDITIONAL_COMPONENTS = Set.of(
-		DataComponents.BANNER_PATTERNS, DataComponents.BEES, DataComponents.BLOCK_ENTITY_DATA,
-		DataComponents.BLOCK_STATE, DataComponents.BUNDLE_CONTENTS, DataComponents.CHARGED_PROJECTILES,
-		DataComponents.CONTAINER, DataComponents.CONTAINER_LOOT, DataComponents.FIREWORK_EXPLOSION,
-		DataComponents.FIREWORKS, DataComponents.INSTRUMENT, DataComponents.MAP_ID,
-		DataComponents.PAINTING_VARIANT, DataComponents.POT_DECORATIONS, DataComponents.POTION_CONTENTS,
-		DataComponents.TROPICAL_FISH_PATTERN, DataComponents.WRITTEN_BOOK_CONTENT,
-		DataComponents.UNBREAKABLE, DataComponents.ATTRIBUTE_MODIFIERS);
 
 	private ItemTooltip() { }
 
-	/**
-	 * Hides or shows the entire tooltip of an item, leaving the components it hides individually
-	 * untouched.
-	 */
 	public static void setEntireHidden(Item item, boolean hidden) {
-		apply(item, display -> new TooltipDisplay(hidden, display.hiddenComponents()));
+		modify(item, display -> display.withHideTooltip(hidden), true);
 	}
 
-	/**
-	 * Hides or shows everything but the name and lore of an item, leaving the rest of its tooltip
-	 * display untouched.
-	 */
 	public static void setAdditionalHidden(Item item, boolean hidden) {
-		apply(item, display -> {
-			Set<DataComponent<?>> hiddenComponents = new HashSet<>(display.hiddenComponents());
-			if (hidden) {
-				hiddenComponents.addAll(ADDITIONAL_COMPONENTS);
-			} else {
-				hiddenComponents.removeAll(ADDITIONAL_COMPONENTS);
-			}
-			return new TooltipDisplay(display.hideTooltip(), hiddenComponents);
-		});
+		if (hidden) {
+			ItemFlag.add(item, true, ItemFlag.HIDE_ADDITIONAL_TOOLTIP);
+		} else {
+			ItemFlag.remove(item, ItemFlag.HIDE_ADDITIONAL_TOOLTIP);
+		}
 	}
 
 	public static boolean isEntireHidden(Item item) {
@@ -66,22 +31,21 @@ public final class ItemTooltip {
 	 * entire tooltip hidden doesn't count, as showing the tooltip again would reveal them.
 	 */
 	public static boolean isAdditionalHidden(Item item) {
-		return getDisplay(item.getItem()).hiddenComponents().containsAll(ADDITIONAL_COMPONENTS);
+		return ItemFlag.getHiddenComponents(item.getItem())
+					   .containsAll(ItemFlag.HIDE_ADDITIONAL_TOOLTIP.getDataComponents());
 	}
 
-	private static TooltipDisplay getDisplay(DataComponent.Holder holder) {
+	public static TooltipDisplay getDisplay(DataComponent.Holder holder) {
 		return holder.get(DataComponents.TOOLTIP_DISPLAY, TooltipDisplay.EMPTY);
 	}
 
-	private static void apply(Item item, UnaryOperator<TooltipDisplay> modifyFunction) {
+	public static void modify(Item item, UnaryOperator<TooltipDisplay> modifyFunction, boolean notify) {
 		item.modify(stack -> {
 			TooltipDisplay display = modifyFunction.apply(getDisplay(stack));
-			TooltipDisplay prototype = getDisplay(stack.material().prototype());
-			// don't leave an explicit override behind if it's what the material does anyway,
-			// otherwise an item that got its tooltip back wouldn't equal a plain one
-			if (display.equals(prototype)) return stack.reset(DataComponents.TOOLTIP_DISPLAY);
+			if (display.equals(getDisplay(stack.material().prototype())))
+				return stack.reset(DataComponents.TOOLTIP_DISPLAY);
 			return stack.with(DataComponents.TOOLTIP_DISPLAY, display);
-		});
+		}, notify);
 	}
 
 }

--- a/minestom/src/main/java/ch/njol/skript/util/ItemTooltip.java
+++ b/minestom/src/main/java/ch/njol/skript/util/ItemTooltip.java
@@ -15,11 +15,9 @@ public final class ItemTooltip {
 	}
 
 	public static void setAdditionalHidden(Item item, boolean hidden) {
-		if (hidden) {
-			ItemFlag.add(item, true, ItemFlag.HIDE_ADDITIONAL_TOOLTIP);
-		} else {
-			ItemFlag.remove(item, ItemFlag.HIDE_ADDITIONAL_TOOLTIP);
-		}
+		if (hidden) ItemFlag.add(item, true, ItemFlag.HIDE_ADDITIONAL_TOOLTIP);
+		else ItemFlag.remove(item, ItemFlag.HIDE_ADDITIONAL_TOOLTIP);
+
 	}
 
 	public static boolean isEntireHidden(Item item) {
@@ -31,8 +29,7 @@ public final class ItemTooltip {
 	 * entire tooltip hidden doesn't count, as showing the tooltip again would reveal them.
 	 */
 	public static boolean isAdditionalHidden(Item item) {
-		return ItemFlag.getHiddenComponents(item.getItem())
-					   .containsAll(ItemFlag.HIDE_ADDITIONAL_TOOLTIP.getDataComponents());
+		return ItemFlag.getHiddenComponents(item.getItem()).containsAll(ItemFlag.HIDE_ADDITIONAL_TOOLTIP.getDataComponents());
 	}
 
 	public static TooltipDisplay getDisplay(DataComponent.Holder holder) {
@@ -42,8 +39,7 @@ public final class ItemTooltip {
 	public static void modify(Item item, UnaryOperator<TooltipDisplay> modifyFunction, boolean notify) {
 		item.modify(stack -> {
 			TooltipDisplay display = modifyFunction.apply(getDisplay(stack));
-			if (display.equals(getDisplay(stack.material().prototype())))
-				return stack.reset(DataComponents.TOOLTIP_DISPLAY);
+			if (display.equals(getDisplay(stack.material().prototype()))) return stack.reset(DataComponents.TOOLTIP_DISPLAY);
 			return stack.with(DataComponents.TOOLTIP_DISPLAY, display);
 		}, notify);
 	}


### PR DESCRIPTION
### Description
Adds syntax for hiding an item's tooltip

### Expression
`%items% with[out] [the|its|their] (entire|additional) tool[ ]tip`

- **entire** hides the whole tooltip, name and lore included
- **additional** hides everything but the name and lore: potion effects,
  banner patterns, attribute modifiers, container contents, and so on

### Condition
`%items% (has|have) [its|their] (entire|additional) tool[ ]tip hidden`
(plus the negated form)

An item only counts as having its additional tooltip hidden if every part of
it is hidden
<!--- Describe your changes here. --->

---
**Target Minecraft Versions:** any <!-- 'any' means all supported versions -->
**Requirements:** none <!-- Required plugins, server software... -->
**Related Issues:** none <!-- Links to related issues -->
